### PR TITLE
refactor: improve typing and error handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,14 @@ import orderPlacedSubscriber from "./subscribers/order-placed"
 import orderCanceledSubscriber from "./subscribers/order-canceled"
 import orderRefundedSubscriber from "./subscribers/order-refunded"
 
-export default async function keygenPlugin(_: LoaderOptions) {
+type Subscriber = (...args: unknown[]) => unknown
+
+export default async function keygenPlugin(
+  _: LoaderOptions
+): Promise<{
+  services: typeof KeygenService[]
+  subscribers: Subscriber[]
+}> {
   return {
     services: [KeygenService],
     subscribers: [


### PR DESCRIPTION
## Summary
- strengthen plugin typing
- add detailed Keygen error classes and typed responses
- harden activation route and order subscriber

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689f385b647c8331854fcb32a1f597c1