### PR TITLE
feat: expose license download API

### DIFF
--- a/src/__tests__/routes.store.licenses.test.ts
+++ b/src/__tests__/routes.store.licenses.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from "vitest"
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { GET as LIST } from "../api/store/me/licenses/route"
+import { POST as DOWNLOAD } from "../api/store/me/licenses/[license_id]/download/route"
+
+const mockRes = (): MedusaResponse => {
+  const r = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  }
+  return r as unknown as MedusaResponse
+}
+
+describe("Store license routes", () => {
+  it("lists customer licenses", async () => {
+    const data = [
+      {
+        keygen_license_id: "lic_1",
+        license_key: "AAAA-BBBB",
+        status: "created",
+        keygen_product_id: "prod_1",
+      },
+    ]
+    const query = { graph: vi.fn().mockResolvedValue({ data }) }
+    const req = {
+      scope: { resolve: (k: string) => (k === "query" ? query : undefined) },
+      user: { id: "cust_1" },
+    } as unknown as MedusaRequest
+    const res = mockRes()
+
+    await LIST(req, res)
+
+    expect(query.graph).toHaveBeenCalledWith(
+      expect.objectContaining({ filters: { customer_id: "cust_1" } })
+    )
+    expect(res.json).toHaveBeenCalledWith({
+      licenses: [
+        {
+          id: "lic_1",
+          key: "AAAA-BBBB",
+          status: "created",
+          product: { id: "prod_1" },
+        },
+      ],
+    })
+  })
+
+  it("creates download link", async () => {
+    const query = {
+      graph: vi.fn().mockResolvedValue({
+        data: [{ keygen_license_id: "lic_1" }],
+      }),
+    }
+    const link = {
+      url: "https://s3.example.com/file",
+      expiresAt: "2030-01-01T00:00:00Z",
+      ttlSeconds: 900,
+    }
+    const keygenService = {
+      createDownloadLink: vi.fn().mockResolvedValue(link),
+    }
+    const req = {
+      params: { license_id: "lic_1" },
+      body: { assetId: "asset_1" },
+      scope: {
+        resolve: (k: string) =>
+          k === "query"
+            ? query
+            : k === "keygenService"
+            ? keygenService
+            : undefined,
+      },
+      user: { id: "cust_1" },
+    } as unknown as MedusaRequest
+    const res = mockRes()
+
+    await DOWNLOAD(req, res)
+
+    expect(keygenService.createDownloadLink).toHaveBeenCalledWith({
+      licenseId: "lic_1",
+      assetId: "asset_1",
+      filename: undefined,
+    })
+    expect(res.status).toHaveBeenCalledWith(201)
+    expect(res.json).toHaveBeenCalledWith({
+      link,
+      licenseId: "lic_1",
+      assetId: "asset_1",
+    })
+  })
+})

--- a/src/api/store/me/licenses/[license_id]/download/route.ts
+++ b/src/api/store/me/licenses/[license_id]/download/route.ts
@@ -1,0 +1,66 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import KeygenService, {
+  DownloadLink,
+} from "../../../../../modules/keygen/service"
+
+type AuthUser = { id?: string; customer_id?: string }
+interface DownloadBody {
+  assetId: string
+  filename?: string
+}
+
+export const POST = async (
+  req: MedusaRequest,
+  res: MedusaResponse<
+    { link: DownloadLink; licenseId: string; assetId: string } | { message: string }
+  >
+) => {
+  const { user, auth } = req as unknown as {
+    user?: AuthUser
+    auth?: AuthUser
+  }
+  const customerId =
+    user?.customer_id ?? user?.id ?? auth?.customer_id ?? auth?.id
+  if (!customerId) {
+    return res.status(401).json({ message: "Unauthorized" })
+  }
+
+  const licenseId = req.params.license_id
+  const body = req.body as DownloadBody | undefined
+  const { assetId, filename } = body || {}
+
+  if (!assetId) {
+    return res.status(400).json({ message: "assetId is required" })
+  }
+
+  const query = req.scope.resolve("query") as {
+    graph<T>(cfg: any): Promise<{ data: T[] | null }>
+  }
+  const { data } = await query.graph<{ keygen_license_id: string }>({
+    entity: "keygen_license",
+    filters: { customer_id: customerId, keygen_license_id: licenseId },
+    fields: ["keygen_license_id"],
+    pagination: { take: 1 },
+  })
+
+  const license = data?.[0]
+  if (!license) {
+    return res.status(404).json({ message: "License not found" })
+  }
+
+  const keygen = req.scope.resolve<KeygenService>("keygenService")
+  try {
+    const link = await keygen.createDownloadLink({
+      licenseId: licenseId,
+      assetId,
+      filename,
+    })
+
+    return res.status(201).json({ link, licenseId, assetId })
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : undefined
+    return res
+      .status(500)
+      .json({ message: msg || "Could not create download link" })
+  }
+}

--- a/src/api/store/me/licenses/[license_id]/route.ts
+++ b/src/api/store/me/licenses/[license_id]/route.ts
@@ -1,0 +1,61 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+type AuthUser = { id?: string; customer_id?: string }
+type LicenseRow = {
+  keygen_license_id: string
+  license_key: string
+  status: string
+  keygen_product_id?: string | null
+}
+type License = {
+  id: string
+  key: string
+  status: string
+  product?: { id: string }
+}
+
+export const GET = async (
+  req: MedusaRequest,
+  res: MedusaResponse<{ license: License } | { message: string }>
+) => {
+  const { user, auth } = req as unknown as {
+    user?: AuthUser
+    auth?: AuthUser
+  }
+  const customerId =
+    user?.customer_id ?? user?.id ?? auth?.customer_id ?? auth?.id
+  if (!customerId) {
+    return res.status(401).json({ message: "Unauthorized" })
+  }
+
+  const licenseId = req.params.license_id
+
+  const query = req.scope.resolve("query") as {
+    graph<T>(cfg: any): Promise<{ data: T[] | null }>
+  }
+  const { data } = await query.graph<LicenseRow>({
+    entity: "keygen_license",
+    filters: { customer_id: customerId, keygen_license_id: licenseId },
+    fields: [
+      "keygen_license_id",
+      "license_key",
+      "status",
+      "keygen_product_id",
+    ],
+    pagination: { take: 1 },
+  })
+
+  const l = data?.[0]
+  if (!l) {
+    return res.status(404).json({ message: "License not found" })
+  }
+
+  const license: License = {
+    id: l.keygen_license_id,
+    key: l.license_key,
+    status: l.status,
+    ...(l.keygen_product_id ? { product: { id: l.keygen_product_id } } : {}),
+  }
+
+  return res.json({ license })
+}

--- a/src/api/store/me/licenses/route.ts
+++ b/src/api/store/me/licenses/route.ts
@@ -1,0 +1,57 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+type AuthUser = { id?: string; customer_id?: string }
+type LicenseRow = {
+  keygen_license_id: string
+  license_key: string
+  status: string
+  keygen_product_id?: string | null
+}
+type License = {
+  id: string
+  key: string
+  status: string
+  product?: { id: string }
+}
+
+export const GET = async (
+  req: MedusaRequest,
+  res: MedusaResponse<{ licenses: License[] } | { message: string }>
+) => {
+  const { user, auth } = req as unknown as {
+    user?: AuthUser
+    auth?: AuthUser
+  }
+  const customerId =
+    user?.customer_id ?? user?.id ?? auth?.customer_id ?? auth?.id
+
+  if (!customerId) {
+    return res.status(401).json({ message: "Unauthorized" })
+  }
+
+  const query = req.scope.resolve("query") as {
+    graph<T>(cfg: any): Promise<{ data: T[] | null }>
+  }
+
+  const { data } = await query.graph<LicenseRow>({
+    entity: "keygen_license",
+    filters: { customer_id: customerId },
+    fields: [
+      "keygen_license_id",
+      "license_key",
+      "status",
+      "keygen_product_id",
+    ],
+  })
+
+  const licenses: License[] = (data ?? []).map((l) => ({
+    id: l.keygen_license_id,
+    key: l.license_key,
+    status: l.status,
+    ...(l.keygen_product_id
+      ? { product: { id: l.keygen_product_id } }
+      : {}),
+  }))
+
+  return res.json({ licenses })
+}


### PR DESCRIPTION
## Summary
- add cached download link generation in Keygen service
- expose store endpoints to list licenses and create download links
- cover new routes with tests
- tighten TypeScript types for license APIs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689f38233ac8833195bebebf560283a0