### PR TITLE
Fix path and typing for download links

### DIFF
--- a/src/api/store/me/licenses/[license_id]/download/route.ts
+++ b/src/api/store/me/licenses/[license_id]/download/route.ts
@@ -1,7 +1,7 @@
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import KeygenService, {
   DownloadLink,
-} from "../../../../../modules/keygen/service"
+} from "../../../../../../modules/keygen/service"
 
 type AuthUser = { id?: string; customer_id?: string }
 interface DownloadBody {

--- a/src/modules/keygen/service.ts
+++ b/src/modules/keygen/service.ts
@@ -448,17 +448,16 @@ export default class KeygenService {
       }
     }
 
-    const body: Record<string, unknown> = {
+    const body = {
       data: {
         type: "download-links",
         relationships: {
           license: { data: { type: "licenses", id: input.licenseId } },
         },
+        ...(input.filename
+          ? { attributes: { filename: input.filename } }
+          : {}),
       },
-    }
-
-    if (input.filename) {
-      body.data.attributes = { filename: input.filename }
     }
 
     let res: Response


### PR DESCRIPTION
## Summary
- fix incorrect import path for download link route
- build download link request body with proper typing

## Testing
- `npx tsc -p tsconfig.json`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689f448aa2148331bd7fe2e230b508a3