### PR TITLE
feat: enhance license listing and detail

### DIFF
--- a/src/__tests__/routes.store.licenses.test.ts
+++ b/src/__tests__/routes.store.licenses.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest"
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { GET as LIST } from "../api/store/me/licenses/route"
+import { GET as DETAIL } from "../api/store/me/licenses/[license_id]/route"
 import { POST as DOWNLOAD } from "../api/store/me/licenses/[license_id]/download/route"
 
 const mockRes = (): MedusaResponse => {
@@ -15,10 +16,10 @@ describe("Store license routes", () => {
   it("lists customer licenses", async () => {
     const data = [
       {
-        keygen_license_id: "lic_1",
-        license_key: "AAAA-BBBB",
-        status: "created",
-        keygen_product_id: "prod_1",
+      keygen_license_id: "lic_1",
+      license_key: "AAAA-BBBB",
+      status: "created",
+      keygen_product_id: "prod_1",
       },
     ]
     const query = { graph: vi.fn().mockResolvedValue({ data }) }
@@ -31,13 +32,16 @@ describe("Store license routes", () => {
     await LIST(req, res)
 
     expect(query.graph).toHaveBeenCalledWith(
-      expect.objectContaining({ filters: { customer_id: "cust_1" } })
+      expect.objectContaining({
+        filters: { customer_id: "cust_1" },
+        orderBy: { created_at: "desc" },
+      })
     )
     expect(res.json).toHaveBeenCalledWith({
       licenses: [
         {
           id: "lic_1",
-          key: "AAAA-BBBB",
+          key: "****-BBBB",
           status: "created",
           product: { id: "prod_1" },
         },
@@ -45,7 +49,7 @@ describe("Store license routes", () => {
     })
   })
 
-  it("supports pagination", async () => {
+  it("supports pagination and filters", async () => {
     const data = [
       {
         keygen_license_id: "lic_1",
@@ -60,7 +64,14 @@ describe("Store license routes", () => {
     const req = {
       scope: { resolve: (k: string) => (k === "query" ? query : undefined) },
       user: { id: "cust_1" },
-      query: { limit: "20", offset: "10", q: "prod", order: "created_at:desc" },
+      query: {
+        limit: "20",
+        offset: "10",
+        q: "prod",
+        order: "created_at:desc",
+        productId: "prod_1",
+        status: "created",
+      },
     } as unknown as MedusaRequest
     const res = mockRes()
 
@@ -68,7 +79,12 @@ describe("Store license routes", () => {
 
     expect(query.graph).toHaveBeenCalledWith(
       expect.objectContaining({
-        filters: { customer_id: "cust_1", q: "prod" },
+        filters: {
+          customer_id: "cust_1",
+          q: "prod",
+          keygen_product_id: "prod_1",
+          status: "created",
+        },
         pagination: { take: 20, skip: 10 },
         orderBy: { created_at: "desc" },
       })
@@ -77,7 +93,7 @@ describe("Store license routes", () => {
       licenses: [
         {
           id: "lic_1",
-          key: "AAAA-BBBB",
+          key: "****-BBBB",
           status: "created",
           product: { id: "prod_1" },
         },
@@ -85,6 +101,50 @@ describe("Store license routes", () => {
       count: 30,
       limit: 20,
       offset: 10,
+    })
+  })
+
+  it("returns license details", async () => {
+    const data = [
+      {
+        keygen_license_id: "lic_1",
+        license_key: "AAAA-BBBB",
+        status: "created",
+        keygen_product_id: "prod_1",
+      },
+    ]
+    const query = { graph: vi.fn().mockResolvedValue({ data }) }
+    const keygenService = {
+      getLicenseWithMachines: vi.fn().mockResolvedValue({
+        id: "lic_1",
+        key: "AAAA-BBBB",
+        status: "active",
+        maxMachines: 2,
+        machines: [{ id: "mach_1" }],
+      }),
+    }
+    const req = {
+      params: { license_id: "lic_1" },
+      scope: {
+        resolve: (k: string) =>
+          k === "query" ? query : k === "keygenService" ? keygenService : undefined,
+      },
+      user: { id: "cust_1" },
+    } as unknown as MedusaRequest
+    const res = mockRes()
+
+    await DETAIL(req, res)
+
+    expect(keygenService.getLicenseWithMachines).toHaveBeenCalledWith("lic_1")
+    expect(res.json).toHaveBeenCalledWith({
+      license: {
+        id: "lic_1",
+        key: "AAAA-BBBB",
+        status: "active",
+        product: { id: "prod_1" },
+        max_machines: 2,
+        machines: [{ id: "mach_1" }],
+      },
     })
   })
 


### PR DESCRIPTION
## Summary
- add filtering, default sorting and key masking to license list
- expose full license details with machines
- test store license summary and detail flows

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689f8723e1ec8331b921d674c104d4c5