### PR TITLE
refactor: improve typings and remove anys

### DIFF
--- a/src/admin/utils/keygen.ts
+++ b/src/admin/utils/keygen.ts
@@ -13,7 +13,16 @@ export const pushRecent = (key: string, value: string) => {
   localStorage.setItem(key, JSON.stringify(arr.slice(0, 10)))
 }
 
-export async function validateOnServer(type: "product" | "policy", id: string) {
+export interface ValidationResponse {
+  ok: boolean
+  data?: { name?: string }
+  message?: string
+}
+
+export async function validateOnServer(
+  type: "product" | "policy",
+  id: string
+): Promise<ValidationResponse> {
   if (!id) return { ok: false, message: "ID missing" }
   const res = await fetch(`/admin/keygen/validate`, {
     method: "POST",

--- a/src/admin/widgets/keygen-variant.tsx
+++ b/src/admin/widgets/keygen-variant.tsx
@@ -3,12 +3,15 @@ import { defineWidgetConfig } from "@medusajs/admin-sdk"
 import type { DetailWidgetProps, AdminProductVariant } from "@medusajs/framework/types"
 import { Container, Heading, Input, Button, Label, Text, Badge, Switch } from "@medusajs/ui"
 import { useEffect, useMemo, useState } from "react"
-import { loadRecent, validateOnServer } from "../utils/keygen"
+import { loadRecent, validateOnServer, ValidationResponse } from "../utils/keygen"
 
 const LS_RECENT_PRODUCTS = "keygen_recent_products"
 const LS_RECENT_POLICIES = "keygen_recent_policies"
 
-async function patchVariantMetadata(variantId: string, meta: Record<string, any>) {
+async function patchVariantMetadata(
+  variantId: string,
+  meta: Record<string, unknown>
+) {
   const res = await fetch(`/admin/variants/${variantId}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -41,19 +44,27 @@ const KeygenVariantWidget = ({ data }: DetailWidgetProps<AdminProductVariant>) =
   }, [])
 
   async function handleValidate() {
-    const resP = kp ? await validateOnServer("product", kp) : { ok: true }
-    const resL = kl ? await validateOnServer("policy", kl) : { ok: true }
-    setVp(resP.ok ? { ok:true, name: (resP as any).data?.name } : { ok:false, message: (resP as any).message })
-    setVl(resL.ok ? { ok:true, name: (resL as any).data?.name } : { ok:false, message: (resL as any).message })
+    const resP: ValidationResponse = kp
+      ? await validateOnServer("product", kp)
+      : { ok: true }
+    const resL: ValidationResponse = kl
+      ? await validateOnServer("policy", kl)
+      : { ok: true }
+    setVp(resP.ok ? { ok: true, name: resP.data?.name } : { ok: false, message: resP.message })
+    setVl(resL.ok ? { ok: true, name: resL.data?.name } : { ok: false, message: resL.message })
   }
 
   async function handleSave() {
     if (autoValidate) {
-      const resP = kp ? await validateOnServer("product", kp) : { ok: true }
-      const resL = kl ? await validateOnServer("policy", kl) : { ok: true }
-      if (!(resP as any).ok || !(resL as any).ok) {
-        setVp((resP as any).ok ? { ok:true, name: (resP as any).data?.name } : { ok:false, message: (resP as any).message })
-        setVl((resL as any).ok ? { ok:true, name: (resL as any).data?.name } : { ok:false, message: (resL as any).message })
+      const resP: ValidationResponse = kp
+        ? await validateOnServer("product", kp)
+        : { ok: true }
+      const resL: ValidationResponse = kl
+        ? await validateOnServer("policy", kl)
+        : { ok: true }
+      if (!resP.ok || !resL.ok) {
+        setVp(resP.ok ? { ok: true, name: resP.data?.name } : { ok: false, message: resP.message })
+        setVl(resL.ok ? { ok: true, name: resL.data?.name } : { ok: false, message: resL.message })
         return
       }
     }

--- a/src/api/admin/keygen/entitlements/route.ts
+++ b/src/api/admin/keygen/entitlements/route.ts
@@ -24,8 +24,10 @@ export const GET = async (_req: MedusaRequest, res: MedusaResponse) => {
     return res.status(r.status).json({ message: text || r.statusText })
   }
 
-  const json = await r.json() as any
-  const data = (json?.data || []).map((e: any) => ({
+  const json = (await r.json()) as {
+    data?: { id?: string; attributes?: { code?: string; name?: string } }[]
+  }
+  const data = (json.data || []).map((e) => ({
     id: e?.id,
     code: e?.attributes?.code,
     name: e?.attributes?.name,

--- a/src/api/admin/keygen/licenses/[order_id]/route.ts
+++ b/src/api/admin/keygen/licenses/[order_id]/route.ts
@@ -1,5 +1,7 @@
 
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import KeygenService from "../../../../../modules/keygen/service"
+
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const { order_id } = req.params as { order_id: string }
   const query = req.scope.resolve("query")
@@ -25,7 +27,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
 
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const { order_id } = req.params as { order_id: string }
-  const keygen = req.scope.resolve<any>("keygenService")
+  const keygen = req.scope.resolve<KeygenService>("keygenService")
   const { policyId, productId, orderItemId } = (req.body ?? {}) as {
     policyId?: string
     productId?: string

--- a/src/api/admin/keygen/machines/[machine_id]/route.ts
+++ b/src/api/admin/keygen/machines/[machine_id]/route.ts
@@ -1,15 +1,15 @@
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import KeygenService from "../../../../../modules/keygen/service"
 
 export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
   const { machine_id } = req.params as { machine_id: string }
-  const keygen = req.scope.resolve<any>("keygenService")
+  const keygen = req.scope.resolve<KeygenService>("keygenService")
 
   try {
     await keygen.deleteMachine(machine_id)
     return res.status(204).json({})
-  } catch (e: any) {
-    return res
-      .status(500)
-      .json({ message: e?.message || "Failed to delete machine" })
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : "Failed to delete machine"
+    return res.status(500).json({ message })
   }
 }

--- a/src/api/admin/keygen/policies/route.ts
+++ b/src/api/admin/keygen/policies/route.ts
@@ -33,8 +33,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     return res.status(r.status).json({ message: text || r.statusText })
   }
 
-  const json = await r.json() as any
-  const data = (json?.data || []).map((p: any) => ({
+  const json = (await r.json()) as {
+    data?: { id?: string; attributes?: { name?: string } }[]
+  }
+  const data = (json.data || []).map((p) => ({
     id: p?.id,
     name: p?.attributes?.name,
   }))
@@ -63,7 +65,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     return res.status(400).json({ message: "productId and name are required fields" })
   }
 
-  const payload: any = {
+  const payload: Record<string, unknown> = {
     data: {
       type: "policies",
       attributes: {
@@ -95,7 +97,9 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     return res.status(r.status).json({ message: text || r.statusText })
   }
 
-  const json = await r.json() as any
+  const json = (await r.json()) as {
+    data?: { id?: string; attributes?: { name?: string } }
+  }
   const id = json?.data?.id
   const createdName = json?.data?.attributes?.name
 

--- a/src/api/admin/keygen/validate/route.ts
+++ b/src/api/admin/keygen/validate/route.ts
@@ -37,7 +37,9 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     return res.status(r.status).json({ message: "Validation failed" })
   }
 
-  const json = (await r.json()) as any
+  const json = (await r.json()) as {
+    data?: { id?: string; attributes?: { name?: string; code?: string } }
+  }
   const name =
     json?.data?.attributes?.name ||
     json?.data?.id ||

--- a/src/api/store/licensing/devices/[machine_id]/route.ts
+++ b/src/api/store/licensing/devices/[machine_id]/route.ts
@@ -1,15 +1,15 @@
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import KeygenService from "../../../../../modules/keygen/service"
 
 export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
   const { machine_id } = req.params as { machine_id: string }
-  const keygen = req.scope.resolve<any>("keygenService")
+  const keygen = req.scope.resolve<KeygenService>("keygenService")
 
   try {
     await keygen.deleteMachine(machine_id)
     return res.status(204).json({})
-  } catch (e: any) {
-    return res
-      .status(500)
-      .json({ message: e?.message || "Failed to delete machine" })
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : "Failed to delete machine"
+    return res.status(500).json({ message })
   }
 }

--- a/src/api/store/me/licenses/[license_id]/download/route.ts
+++ b/src/api/store/me/licenses/[license_id]/download/route.ts
@@ -34,7 +34,7 @@ export const POST = async (
   }
 
   const query = req.scope.resolve("query") as {
-    graph<T>(cfg: any): Promise<{ data: T[] | null }>
+    graph<T>(cfg: Record<string, unknown>): Promise<{ data: T[] | null }>
   }
   const { data } = await query.graph<{ keygen_license_id: string }>({
     entity: "keygen_license",

--- a/src/api/store/me/licenses/[license_id]/route.ts
+++ b/src/api/store/me/licenses/[license_id]/route.ts
@@ -39,7 +39,7 @@ export const GET = async (
   const licenseId = req.params.license_id
 
   const query = req.scope.resolve("query") as {
-    graph<T>(cfg: any): Promise<{ data: T[] | null }>
+    graph<T>(cfg: Record<string, unknown>): Promise<{ data: T[] | null }>
   }
   const { data } = await query.graph<LicenseRow>({
     entity: "keygen_license",
@@ -59,12 +59,18 @@ export const GET = async (
   }
 
   const keygen = req.scope.resolve<KeygenService>("keygenService")
-  let det: {
-    key?: string
-    status?: string
+  type LicenseDetails = {
+    key?: string | null
+    status?: string | null
     maxMachines?: number
-    machines?: any[]
-  } | null = null
+    machines?: {
+      id?: string
+      name?: string | null
+      fingerprint?: string | null
+      platform?: string | null
+    }[]
+  }
+  let det: LicenseDetails | null = null
   try {
     det = await keygen.getLicenseWithMachines(l.keygen_license_id)
   } catch (_) {

--- a/src/api/store/me/licenses/route.ts
+++ b/src/api/store/me/licenses/route.ts
@@ -44,7 +44,10 @@ export const GET = async (
   }
 
   const query = req.scope.resolve("query") as {
-    graph<T>(cfg: any): Promise<{ data: T[] | null; metadata?: { count?: number } }>
+    graph<T>(cfg: Record<string, unknown>): Promise<{
+      data: T[] | null
+      metadata?: { count?: number }
+    }>
   }
 
   const {
@@ -77,13 +80,13 @@ export const GET = async (
     orderBy = { [field]: (direction as "asc" | "desc") ?? "asc" }
   }
 
-  const filters: Record<string, any> = { customer_id: customerId }
+  const filters: Record<string, unknown> = { customer_id: customerId }
   if (q) filters.q = q
   const prodFilter = productId ?? product_id
   if (prodFilter) filters.keygen_product_id = prodFilter
   if (status) filters.status = status
 
-  const cfg: any = {
+  const cfg: Record<string, unknown> = {
     entity: "keygen_license",
     filters,
     fields: [

--- a/src/middleware/verify-keygen-webhook.ts
+++ b/src/middleware/verify-keygen-webhook.ts
@@ -1,8 +1,16 @@
 import crypto from "crypto"
+import type { Request, Response, NextFunction } from "express"
 
-export default function verifyKeygenWebhook(req: any, res: any, next: any) {
+type RawRequest = Request & { rawBody?: Buffer | string }
+
+export default function verifyKeygenWebhook(
+  req: RawRequest,
+  res: Response,
+  next: NextFunction
+) {
   const secret = process.env.KEYGEN_WEBHOOK_SECRET
-  const signature = req.headers?.["x-signature"]
+  const signatureHeader = req.headers["x-signature"]
+  const signature = Array.isArray(signatureHeader) ? signatureHeader[0] : signatureHeader
 
   if (!secret || !signature) {
     res.status?.(401).json?.({ message: "Invalid signature" })

--- a/src/subscribers/order-placed.ts
+++ b/src/subscribers/order-placed.ts
@@ -6,13 +6,15 @@ import type { KeygenPluginOptions } from "../types"
 export default async function orderPlacedSubscriber({
   container,
   event,
-}: SubscriberArgs<any>) {
+}: SubscriberArgs<{ id: string }>) {
   if (event.name !== "order.placed") return
 
   const logger = container.resolve("logger")
-  const config = container.resolve<any>("configModule")
-  const pluginCfg = (config?.plugins || []).find(
-    (p: any) => typeof p?.resolve === "string" && p.resolve.includes("medusa-plugin-keygen")
+  const config = container.resolve("configModule") as {
+    plugins?: { resolve?: string; options?: KeygenPluginOptions }[]
+  }
+  const pluginCfg = (config.plugins || []).find(
+    (p) => typeof p?.resolve === "string" && p.resolve.includes("medusa-plugin-keygen")
   )
   const options: KeygenPluginOptions = pluginCfg?.options || {}
 
@@ -66,7 +68,8 @@ export default async function orderPlacedSubscriber({
         `[keygen] license created for order ${order.id} / item ${item.id}: ${record?.license_key}`
       )
     }
-  } catch (e: any) {
-    logger.error(`[keygen] failed on order.placed: ${e?.message}`)
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e)
+    logger.error(`[keygen] failed on order.placed: ${msg}`)
   }
 }


### PR DESCRIPTION
## Summary
- replace `any` with explicit interfaces and records across Keygen service and routes
- add typed webhook middleware and admin utilities
- strengthen subscriber and activation route typings

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a00bfafbd483318bc16c287b6cc3ec