### PR TITLE
docs: clarify Keygen service and routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ Includes **admin widgets** (product & variant) and **admin server routes** (vali
 The licenses endpoint lets you fetch existing licenses for an order or manually
 generate them if needed.
 
+## KeygenService API
+The plugin registers a `keygenService` on the Medusa container. It provides helpers for common licensing operations:
+
+- `createLicense(input)` – create a license in Keygen and persist it locally
+- `suspendLicense(licenseId)` – suspend an existing license
+- `revokeLicense(licenseId)` – revoke a license permanently
+- `getLicenseWithMachines(licenseId)` – retrieve a license along with its machines
+- `activateMachine(input)` – attach a machine to a license, enforcing seat limits
+- `deleteMachine(machineId)` – remove a machine from Keygen
+- `createDownloadLink(input)` – generate and cache a temporary asset download URL
+
 ## Installation
 ```bash
 npm i medusa-plugin-keygen

--- a/src/api/admin/keygen/licenses/[order_id]/route.ts
+++ b/src/api/admin/keygen/licenses/[order_id]/route.ts
@@ -2,6 +2,7 @@
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import KeygenService from "../../../../../modules/keygen/service"
 
+// Lists all Keygen licenses for a given order.
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const { order_id } = req.params as { order_id: string }
   const query = req.scope.resolve("query")
@@ -25,6 +26,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   res.json({ licenses: data })
 }
 
+// Manually issues a new license for the provided order.
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const { order_id } = req.params as { order_id: string }
   const keygen = req.scope.resolve<KeygenService>("keygenService")


### PR DESCRIPTION
## Summary
- document key KeygenService methods
- explain admin license route behavior
- describe service functions in README

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a0e63513a08331972fc38141fe2a92