### PR TITLE
chore: set up ESLint and Prettier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[{*.js,*.ts}]
+indent_size=2

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,28 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  extends: ['plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended'],
+  plugins: ['@typescript-eslint/eslint-plugin'],
+  parserOptions: {
+    project: ['./tsconfig.eslint.json'],
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    tsconfigRootDir: __dirname,
+  },
+  env: {
+    node: true,
+    jest: true,
+  },
+  ignorePatterns: ['.eslintrc.js'],
+  rules: {
+    '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { argsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_', ignoreRestSiblings: true },
+    ],
+  },
+}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ pnpm-lock.yaml
 dist
 coverage
 
+# ESLint cache
+.eslintcache
+
 # Mac
 .DS_Store
 

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "tabWidth": 2,
+  "printWidth": 120,
+  "semi": false
+}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-
 # medusa-plugin-keygen
 
 Medusa v2 plugin that creates **licenses via keygen.sh** when an order is placed.
 Includes **admin widgets** (product & variant) and **admin server routes** (validation, policy management).
 
 ## Features
+
 - **Subscriber**: listens for `order.placed` (creates a license for each line item),
   `order.canceled` (suspends licenses) and `order.refunded` (revokes licenses)
 - **Data Model**: `keygen_license` table (order_id, license_id, key, status, etc.)
@@ -31,9 +31,7 @@ Includes **admin widgets** (product & variant) and **admin server routes** (vali
 - Example paginated response:
   ```json
   {
-    "licenses": [
-      { "id": "lic_123", "key": "XXXX-YYYY", "status": "active" }
-    ],
+    "licenses": [{ "id": "lic_123", "key": "XXXX-YYYY", "status": "active" }],
     "count": 65,
     "limit": 20,
     "offset": 0
@@ -46,6 +44,7 @@ The licenses endpoint lets you fetch existing licenses for an order or manually
 generate them if needed.
 
 ## KeygenService API
+
 The plugin registers a `keygenService` on the Medusa container. It provides helpers for common licensing operations:
 
 - `createLicense(input)` – create a license in Keygen and persist it locally
@@ -57,21 +56,23 @@ The plugin registers a `keygenService` on the Medusa container. It provides help
 - `createDownloadLink(input)` – generate and cache a temporary asset download URL
 
 ## Installation
+
 ```bash
 npm i medusa-plugin-keygen
 ```
 
 Register in `medusa-config.ts`:
+
 ```ts
-import { defineConfig } from "@medusajs/medusa"
+import { defineConfig } from '@medusajs/medusa'
 
 export default defineConfig({
   plugins: [
     {
-      resolve: "medusa-plugin-keygen",
+      resolve: 'medusa-plugin-keygen',
       options: {
-        policyMetadataKey: "keygen_policy",
-        productMetadataKey: "keygen_product",
+        policyMetadataKey: 'keygen_policy',
+        productMetadataKey: 'keygen_product',
         // defaultPolicyId: "pol_123",
         // defaultProductId: "prod_123",
         timeoutMs: 12000,
@@ -82,6 +83,7 @@ export default defineConfig({
 ```
 
 Set the environment variables in your app:
+
 ```
 KEYGEN_ACCOUNT=your-account-or-slug
 KEYGEN_TOKEN=your-api-token
@@ -89,7 +91,6 @@ KEYGEN_TOKEN=your-api-token
 # defaults to https://api.keygen.sh
 KEYGEN_HOST=https://keygen.example.com
 ```
-
 
 A `.env.example` file is included with placeholder values for these variables.
 
@@ -106,16 +107,19 @@ The plugin will then call your self-hosted API instead of the default
 `https://api.keygen.sh`.
 
 Migrations:
+
 ```bash
 npx medusa plugin:db:generate  # inside the plugin (optional)
 npx medusa db:migrate         # in your app (runs plugin migrations)
 ```
 
 ## Admin
+
 - Product detail page: set/validate IDs, create/clone policies, attach entitlements
 - Variant view: set metadata per variant
 
 ## Tests
+
 ```bash
 npm i
 npm run build
@@ -123,9 +127,11 @@ npm test
 ```
 
 ## Use from GitHub
+
 - Create a repo (e.g., `YOUR_ORG/medusa-plugin-keygen`) and push the files
 - Bump the version (SemVer), tag it (e.g., `v0.1.0`)
 - Optional: GitHub release / npm publish
 
 ## License
+
 MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,12 @@
         "@medusajs/framework": "^2.8.0",
         "@medusajs/medusa": "^2.8.0",
         "@types/node": "^20.11.5",
+        "@typescript-eslint/eslint-plugin": "^8.21.0",
+        "@typescript-eslint/parser": "^8.21.0",
+        "eslint": "^8",
+        "eslint-config-prettier": "^10.0.1",
+        "eslint-plugin-prettier": "^5.2.3",
+        "prettier": "^3.4.2",
         "typescript": "^5.4.0",
         "vitest": "^1.6.0"
       },
@@ -2075,6 +2081,166 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
@@ -2425,6 +2591,68 @@
       "peerDependencies": {
         "react-hook-form": "^7.0.0"
       }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@inquirer/checkbox": {
       "version": "2.5.0",
@@ -4799,6 +5027,19 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -14606,6 +14847,264 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.1.tgz",
+      "integrity": "sha512-yYegZ5n3Yr6eOcqgj2nJH8cH/ZZgF+l0YIdKILSDjYFRjgYQMgv/lRjV5Z7Up04b9VYUondt8EPMqg7kTWgJ2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.39.1",
+        "@typescript-eslint/type-utils": "8.39.1",
+        "@typescript-eslint/utils": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
+        "graphemer": "^1.4.0",
+        "ignore": "^7.0.0",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.39.1",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.39.1.tgz",
+      "integrity": "sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.39.1.tgz",
+      "integrity": "sha512-8fZxek3ONTwBu9ptw5nCKqZOSkXshZB7uAxuFF0J/wTMkKydjXCzqqga7MlFMpHi9DoG4BadhmTkITBcg8Aybw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.39.1",
+        "@typescript-eslint/types": "^8.39.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.39.1.tgz",
+      "integrity": "sha512-RkBKGBrjgskFGWuyUGz/EtD8AF/GW49S21J8dvMzpJitOF1slLEbbHnNEtAHtnDAnx8qDEdRrULRnWVx27wGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.1.tgz",
+      "integrity": "sha512-ePUPGVtTMR8XMU2Hee8kD0Pu4NDE1CN9Q1sxGSGd/mbOtGZDM7pnhXNJnzW63zk/q+Z54zVzj44HtwXln5CvHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.39.1.tgz",
+      "integrity": "sha512-gu9/ahyatyAdQbKeHnhT4R+y3YLtqqHyvkfDxaBYk97EcbfChSJXyaJnIL3ygUv7OuZatePHmQvuH5ru0lnVeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1",
+        "@typescript-eslint/utils": "8.39.1",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.1.tgz",
+      "integrity": "sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.1.tgz",
+      "integrity": "sha512-EKkpcPuIux48dddVDXyQBlKdeTPMmALqBUbEk38McWv0qVEZwOpVJBi7ugK5qVNgeuYjGNQxrrnoM/5+TI/BPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.39.1",
+        "@typescript-eslint/tsconfig-utils": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/visitor-keys": "8.39.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.39.1.tgz",
+      "integrity": "sha512-VF5tZ2XnUSTuiqZFXCZfZs1cgkdd3O/sSYmdo2EpSyDlC86UM/8YytTmKnehOW3TGAlivqTDT6bS87B/GQ/jyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.39.1",
+        "@typescript-eslint/types": "8.39.1",
+        "@typescript-eslint/typescript-estree": "8.39.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.39.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.1.tgz",
+      "integrity": "sha512-W8FQi6kEh2e8zVhQ0eeRnxdvIoOkAp/CPAahcNio6nO9dsIwb9b34z90KOlheoyuVf6LSOEdjlkxSkapNEc+4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.39.1",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@uiw/react-json-view": {
       "version": "2.0.0-alpha.34",
       "resolved": "https://registry.npmjs.org/@uiw/react-json-view/-/react-json-view-2.0.0-alpha.34.tgz",
@@ -14620,6 +15119,13 @@
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -14754,6 +15260,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/acorn-walk": {
@@ -15504,6 +16020,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camel-case": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
@@ -16133,6 +16659,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
@@ -16498,6 +17031,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -16635,6 +17175,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/dom-walk": {
@@ -16905,6 +17458,341 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
+      "integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.11.7"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/esm": {
       "version": "3.2.25",
       "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
@@ -16914,6 +17802,24 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esprima": {
@@ -16930,6 +17836,42 @@
         "node": ">=4"
       }
     },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -16938,6 +17880,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -17182,8 +18134,14 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -17201,6 +18159,20 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
@@ -17332,6 +18304,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -17394,6 +18379,28 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
@@ -17540,6 +18547,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -17785,6 +18799,13 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/graphql": {
       "version": "16.11.0",
@@ -18053,6 +19074,33 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/import-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
@@ -18095,6 +19143,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -18392,6 +19452,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-relative": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
@@ -18606,6 +19676,13 @@
         "node": ">= 16"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -18613,6 +19690,13 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -18697,6 +19781,16 @@
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kleur": {
@@ -18803,6 +19897,20 @@
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -18914,6 +20022,13 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -19517,6 +20632,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/natural-orderby": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.3.tgz",
@@ -19727,6 +20849,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/one-time": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
@@ -19751,6 +20883,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/ora": {
@@ -19857,6 +21007,19 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-require": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parent-require/-/parent-require-1.0.0.tgz",
@@ -19932,6 +21095,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -20492,6 +21665,45 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -20622,7 +21834,6 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -21726,6 +22937,69 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.2.tgz",
@@ -22361,6 +23635,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-literal": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
@@ -22491,6 +23778,22 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
+      "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.9"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
@@ -22568,6 +23871,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
       "license": "MIT"
     },
@@ -22706,6 +24016,19 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -22734,6 +24057,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-detect": {
       "version": "4.1.0",
@@ -22999,7 +24335,6 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -23539,6 +24874,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -23572,6 +24917,13 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -20,13 +20,23 @@
     "@medusajs/framework": "^2.8.0",
     "@medusajs/medusa": "^2.8.0",
     "@types/node": "^20.11.5",
+    "@typescript-eslint/eslint-plugin": "^8.21.0",
+    "@typescript-eslint/parser": "^8.21.0",
+    "eslint": "^8",
+    "eslint-config-prettier": "^10.0.1",
+    "eslint-plugin-prettier": "^5.2.3",
+    "prettier": "^3.4.2",
     "typescript": "^5.4.0",
     "vitest": "^1.6.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "lint": "eslint --ext .js,.ts src --cache --cache-strategy content",
+    "lint:fix": "eslint --ext .js,.ts src --fix --cache --cache-strategy content",
+    "format": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md}\" --cache --cache-strategy content --log-level warn",
+    "format:fix": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\" --cache --cache-strategy content --log-level warn"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/src/__tests__/env.test.ts
+++ b/src/__tests__/env.test.ts
@@ -1,13 +1,13 @@
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect, vi } from 'vitest'
 
-describe("env config", () => {
-  it("throws if required vars are missing", async () => {
+describe('env config', () => {
+  it('throws if required vars are missing', async () => {
     const origAcc = process.env.KEYGEN_ACCOUNT
     const origTok = process.env.KEYGEN_TOKEN
     vi.resetModules()
     delete process.env.KEYGEN_ACCOUNT
     delete process.env.KEYGEN_TOKEN
-    await expect(import("../config/env")).rejects.toThrow()
+    await expect(import('../config/env')).rejects.toThrow()
     process.env.KEYGEN_ACCOUNT = origAcc
     process.env.KEYGEN_TOKEN = origTok
   })

--- a/src/__tests__/middleware.verify-keygen-webhook.test.ts
+++ b/src/__tests__/middleware.verify-keygen-webhook.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
-import crypto from "crypto"
-import verifyKeygenWebhook from "../middleware/verify-keygen-webhook"
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import crypto from 'crypto'
+import verifyKeygenWebhook from '../middleware/verify-keygen-webhook'
 
-describe("verifyKeygenWebhook", () => {
+describe('verifyKeygenWebhook', () => {
   beforeEach(() => {
-    process.env.KEYGEN_WEBHOOK_SECRET = "test_secret"
+    process.env.KEYGEN_WEBHOOK_SECRET = 'test_secret'
   })
 
   const mockRes = () => {
@@ -14,12 +14,12 @@ describe("verifyKeygenWebhook", () => {
     return r
   }
 
-  it("calls next for valid signature", () => {
-    const payload = { foo: "bar" }
+  it('calls next for valid signature', () => {
+    const payload = { foo: 'bar' }
     const raw = JSON.stringify(payload)
-    const sig = crypto.createHmac("sha256", "test_secret").update(raw).digest("hex")
+    const sig = crypto.createHmac('sha256', 'test_secret').update(raw).digest('hex')
 
-    const req: any = { headers: { "x-signature": sig }, rawBody: raw }
+    const req: any = { headers: { 'x-signature': sig }, rawBody: raw }
     const res = mockRes()
     const next = vi.fn()
 
@@ -29,32 +29,32 @@ describe("verifyKeygenWebhook", () => {
     expect(res.status).not.toHaveBeenCalled()
   })
 
-  it("rejects invalid signature", () => {
-    const payload = { foo: "bar" }
+  it('rejects invalid signature', () => {
+    const payload = { foo: 'bar' }
     const raw = JSON.stringify(payload)
 
-    const req: any = { headers: { "x-signature": "bad" }, rawBody: raw }
+    const req: any = { headers: { 'x-signature': 'bad' }, rawBody: raw }
     const res = mockRes()
     const next = vi.fn()
 
     verifyKeygenWebhook(req, res, next)
 
     expect(res.status).toHaveBeenCalledWith(401)
-    expect(res.json).toHaveBeenCalledWith({ message: "Invalid signature" })
+    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid signature' })
     expect(next).not.toHaveBeenCalled()
   })
 
-  it("fails when raw body is missing", () => {
-    const sig = crypto.createHmac("sha256", "test_secret").update("payload").digest("hex")
+  it('fails when raw body is missing', () => {
+    const sig = crypto.createHmac('sha256', 'test_secret').update('payload').digest('hex')
 
-    const req: any = { headers: { "x-signature": sig } }
+    const req: any = { headers: { 'x-signature': sig } }
     const res = mockRes()
     const next = vi.fn()
 
     verifyKeygenWebhook(req, res, next)
 
     expect(res.status).toHaveBeenCalledWith(400)
-    expect(res.json).toHaveBeenCalledWith({ message: "Missing raw body" })
+    expect(res.json).toHaveBeenCalledWith({ message: 'Missing raw body' })
     expect(next).not.toHaveBeenCalled()
   })
 })

--- a/src/__tests__/routes.licenses.test.ts
+++ b/src/__tests__/routes.licenses.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest"
-import { GET, POST } from "../api/admin/keygen/licenses/[order_id]/route"
+import { describe, it, expect, vi } from 'vitest'
+import { GET, POST } from '../api/admin/keygen/licenses/[order_id]/route'
 
 const mockRes = () => {
   const r: any = {}
@@ -8,20 +8,20 @@ const mockRes = () => {
   return r
 }
 
-describe("Licenses routes", () => {
-  it("returns stored licenses", async () => {
+describe('Licenses routes', () => {
+  it('returns stored licenses', async () => {
     const data = [
       {
-        id: "lic_db_1",
-        order_id: "order_1",
-        license_key: "AAAA-BBBB-CCCC",
-        keygen_license_id: "lic_1",
+        id: 'lic_db_1',
+        order_id: 'order_1',
+        license_key: 'AAAA-BBBB-CCCC',
+        keygen_license_id: 'lic_1',
       },
     ]
     const query = { graph: vi.fn().mockResolvedValue({ data }) }
     const req: any = {
-      params: { order_id: "order_1" },
-      scope: { resolve: (key: string) => (key === "query" ? query : undefined) },
+      params: { order_id: 'order_1' },
+      scope: { resolve: (key: string) => (key === 'query' ? query : undefined) },
     }
     const res: any = mockRes()
 
@@ -29,53 +29,52 @@ describe("Licenses routes", () => {
 
     expect(query.graph).toHaveBeenCalledWith(
       expect.objectContaining({
-        entity: "keygen_license",
-        filters: { order_id: "order_1" },
-      })
+        entity: 'keygen_license',
+        filters: { order_id: 'order_1' },
+      }),
     )
     expect(res.json).toHaveBeenCalledWith({ licenses: data })
   })
 
-  it("creates a license via service", async () => {
-    const record = { id: "lic_db_2", license_key: "DDDD-EEEE-FFFF" }
+  it('creates a license via service', async () => {
+    const record = { id: 'lic_db_2', license_key: 'DDDD-EEEE-FFFF' }
     const keygenService = {
       createLicense: vi.fn().mockResolvedValue({ record }),
     }
     const req: any = {
-      params: { order_id: "order_1" },
-      body: { policyId: "pol_1", productId: "prod_1", orderItemId: "item_1" },
-      scope: { resolve: (key: string) => (key === "keygenService" ? keygenService : undefined) },
+      params: { order_id: 'order_1' },
+      body: { policyId: 'pol_1', productId: 'prod_1', orderItemId: 'item_1' },
+      scope: { resolve: (key: string) => (key === 'keygenService' ? keygenService : undefined) },
     }
     const res: any = mockRes()
 
     await POST(req, res)
 
     expect(keygenService.createLicense).toHaveBeenCalledWith({
-      orderId: "order_1",
-      orderItemId: "item_1",
-      policyId: "pol_1",
-      productId: "prod_1",
+      orderId: 'order_1',
+      orderItemId: 'item_1',
+      policyId: 'pol_1',
+      productId: 'prod_1',
     })
     expect(res.status).toHaveBeenCalledWith(201)
     expect(res.json).toHaveBeenCalledWith({ license: record })
   })
 
-  it("requires policyId or productId", async () => {
+  it('requires policyId or productId', async () => {
     const keygenService = {
       createLicense: vi.fn(),
     }
     const req: any = {
-      params: { order_id: "order_1" },
+      params: { order_id: 'order_1' },
       body: {},
-      scope: { resolve: (key: string) => (key === "keygenService" ? keygenService : undefined) },
+      scope: { resolve: (key: string) => (key === 'keygenService' ? keygenService : undefined) },
     }
     const res: any = mockRes()
 
     await POST(req, res)
 
     expect(res.status).toHaveBeenCalledWith(400)
-    expect(res.json).toHaveBeenCalledWith({ message: "policyId or productId required" })
+    expect(res.json).toHaveBeenCalledWith({ message: 'policyId or productId required' })
     expect(keygenService.createLicense).not.toHaveBeenCalled()
   })
 })
-

--- a/src/__tests__/routes.policies.test.ts
+++ b/src/__tests__/routes.policies.test.ts
@@ -1,5 +1,4 @@
-
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mockRes = () => {
   const r: any = {}
@@ -8,62 +7,66 @@ const mockRes = () => {
   return r
 }
 
-describe("Policies routes", () => {
+describe('Policies routes', () => {
   beforeEach(() => {
-    process.env.KEYGEN_ACCOUNT = "acct_123"
-    process.env.KEYGEN_TOKEN = "tok_123"
+    process.env.KEYGEN_ACCOUNT = 'acct_123'
+    process.env.KEYGEN_TOKEN = 'tok_123'
     vi.resetModules()
   })
 
-  it("creates a policy", async () => {
-    // @ts-ignore
+  it('creates a policy', async () => {
+    // @ts-expect-error mock fetch
     global.fetch = vi.fn().mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ data: { id: "pol_new", attributes: { name: "Annual – 2 Seats" } } })
+      json: async () => ({ data: { id: 'pol_new', attributes: { name: 'Annual – 2 Seats' } } }),
     })
 
-    const { POST: createPolicy } = await import("../api/admin/keygen/policies/route")
-    const req: any = { body: { productId: "prod_1", name: "Annual – 2 Seats", maxMachines: 2 } }
+    const { POST: createPolicy } = await import('../api/admin/keygen/policies/route')
+    const req: any = { body: { productId: 'prod_1', name: 'Annual – 2 Seats', maxMachines: 2 } }
     const res: any = mockRes()
 
     await createPolicy(req, res)
     expect(res.status).toHaveBeenCalledWith(201)
-    expect(res.json).toHaveBeenCalledWith({ id: "pol_new", name: "Annual – 2 Seats" })
+    expect(res.json).toHaveBeenCalledWith({ id: 'pol_new', name: 'Annual – 2 Seats' })
     expect(global.fetch).toHaveBeenCalledWith(
-      "https://api.keygen.sh/v1/accounts/acct_123/policies",
+      'https://api.keygen.sh/v1/accounts/acct_123/policies',
       expect.objectContaining({
-        headers: expect.objectContaining({ "Keygen-Version": "1.8" })
-      })
+        headers: expect.objectContaining({ 'Keygen-Version': '1.8' }),
+      }),
     )
   })
 
-  it("clones a policy", async () => {
-    ;(global as any).fetch = vi.fn()
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { id: "pol_src", attributes: { name: "Src", maxMachines: 2 } } }) })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { id: "pol_cloned" } }) })
+  it('clones a policy', async () => {
+    ;(global as any).fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { id: 'pol_src', attributes: { name: 'Src', maxMachines: 2 } } }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: { id: 'pol_cloned' } }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ data: [] }) })
 
-    const { POST: clonePolicy } = await import("../api/admin/keygen/policies/clone/route")
-    const req: any = { body: { sourcePolicyId: "pol_src", targetProductId: "prod_2" } }
+    const { POST: clonePolicy } = await import('../api/admin/keygen/policies/clone/route')
+    const req: any = { body: { sourcePolicyId: 'pol_src', targetProductId: 'prod_2' } }
     const res: any = mockRes()
 
     await clonePolicy(req, res)
     expect(res.status).toHaveBeenCalledWith(201)
-    expect(res.json).toHaveBeenCalledWith({ id: "pol_cloned" })
+    expect(res.json).toHaveBeenCalledWith({ id: 'pol_cloned' })
     expect((global as any).fetch).toHaveBeenNthCalledWith(
       1,
-      "https://api.keygen.sh/v1/accounts/acct_123/policies/pol_src",
-      expect.objectContaining({ headers: expect.objectContaining({ "Keygen-Version": "1.8" }) })
+      'https://api.keygen.sh/v1/accounts/acct_123/policies/pol_src',
+      expect.objectContaining({ headers: expect.objectContaining({ 'Keygen-Version': '1.8' }) }),
     )
     expect((global as any).fetch).toHaveBeenNthCalledWith(
       2,
-      "https://api.keygen.sh/v1/accounts/acct_123/policies",
-      expect.objectContaining({ headers: expect.objectContaining({ "Keygen-Version": "1.8" }) })
+      'https://api.keygen.sh/v1/accounts/acct_123/policies',
+      expect.objectContaining({ headers: expect.objectContaining({ 'Keygen-Version': '1.8' }) }),
     )
     expect((global as any).fetch).toHaveBeenNthCalledWith(
       3,
-      "https://api.keygen.sh/v1/accounts/acct_123/policies/pol_src/entitlements",
-      expect.objectContaining({ headers: expect.objectContaining({ "Keygen-Version": "1.8" }) })
+      'https://api.keygen.sh/v1/accounts/acct_123/policies/pol_src/entitlements',
+      expect.objectContaining({ headers: expect.objectContaining({ 'Keygen-Version': '1.8' }) }),
     )
   })
 })

--- a/src/__tests__/routes.store.licenses.test.ts
+++ b/src/__tests__/routes.store.licenses.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi } from "vitest"
-import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { GET as LIST } from "../api/store/me/licenses/route"
-import { GET as DETAIL } from "../api/store/me/licenses/[license_id]/route"
-import { POST as DOWNLOAD } from "../api/store/me/licenses/[license_id]/download/route"
+import { describe, it, expect, vi } from 'vitest'
+import type { MedusaRequest, MedusaResponse } from '@medusajs/framework/http'
+import { GET as LIST } from '../api/store/me/licenses/route'
+import { GET as DETAIL } from '../api/store/me/licenses/[license_id]/route'
+import { POST as DOWNLOAD } from '../api/store/me/licenses/[license_id]/download/route'
 
 const mockRes = (): MedusaResponse => {
   const r = {
@@ -12,20 +12,20 @@ const mockRes = (): MedusaResponse => {
   return r as unknown as MedusaResponse
 }
 
-describe("Store license routes", () => {
-  it("lists customer licenses", async () => {
+describe('Store license routes', () => {
+  it('lists customer licenses', async () => {
     const data = [
       {
-      keygen_license_id: "lic_1",
-      license_key: "AAAA-BBBB",
-      status: "created",
-      keygen_product_id: "prod_1",
+        keygen_license_id: 'lic_1',
+        license_key: 'AAAA-BBBB',
+        status: 'created',
+        keygen_product_id: 'prod_1',
       },
     ]
     const query = { graph: vi.fn().mockResolvedValue({ data }) }
     const req = {
-      scope: { resolve: (k: string) => (k === "query" ? query : undefined) },
-      user: { id: "cust_1" },
+      scope: { resolve: (k: string) => (k === 'query' ? query : undefined) },
+      user: { id: 'cust_1' },
     } as unknown as MedusaRequest
     const res = mockRes()
 
@@ -33,44 +33,44 @@ describe("Store license routes", () => {
 
     expect(query.graph).toHaveBeenCalledWith(
       expect.objectContaining({
-        filters: { customer_id: "cust_1" },
-        orderBy: { created_at: "desc" },
-      })
+        filters: { customer_id: 'cust_1' },
+        orderBy: { created_at: 'desc' },
+      }),
     )
     expect(res.json).toHaveBeenCalledWith({
       licenses: [
         {
-          id: "lic_1",
-          key: "****-BBBB",
-          status: "created",
-          product: { id: "prod_1" },
+          id: 'lic_1',
+          key: '****-BBBB',
+          status: 'created',
+          product: { id: 'prod_1' },
         },
       ],
     })
   })
 
-  it("supports pagination and filters", async () => {
+  it('supports pagination and filters', async () => {
     const data = [
       {
-        keygen_license_id: "lic_1",
-        license_key: "AAAA-BBBB",
-        status: "created",
-        keygen_product_id: "prod_1",
+        keygen_license_id: 'lic_1',
+        license_key: 'AAAA-BBBB',
+        status: 'created',
+        keygen_product_id: 'prod_1',
       },
     ]
     const query = {
       graph: vi.fn().mockResolvedValue({ data, metadata: { count: 30 } }),
     }
     const req = {
-      scope: { resolve: (k: string) => (k === "query" ? query : undefined) },
-      user: { id: "cust_1" },
+      scope: { resolve: (k: string) => (k === 'query' ? query : undefined) },
+      user: { id: 'cust_1' },
       query: {
-        limit: "20",
-        offset: "10",
-        q: "prod",
-        order: "created_at:desc",
-        productId: "prod_1",
-        status: "created",
+        limit: '20',
+        offset: '10',
+        q: 'prod',
+        order: 'created_at:desc',
+        productId: 'prod_1',
+        status: 'created',
       },
     } as unknown as MedusaRequest
     const res = mockRes()
@@ -80,22 +80,22 @@ describe("Store license routes", () => {
     expect(query.graph).toHaveBeenCalledWith(
       expect.objectContaining({
         filters: {
-          customer_id: "cust_1",
-          q: "prod",
-          keygen_product_id: "prod_1",
-          status: "created",
+          customer_id: 'cust_1',
+          q: 'prod',
+          keygen_product_id: 'prod_1',
+          status: 'created',
         },
         pagination: { take: 20, skip: 10 },
-        orderBy: { created_at: "desc" },
-      })
+        orderBy: { created_at: 'desc' },
+      }),
     )
     expect(res.json).toHaveBeenCalledWith({
       licenses: [
         {
-          id: "lic_1",
-          key: "****-BBBB",
-          status: "created",
-          product: { id: "prod_1" },
+          id: 'lic_1',
+          key: '****-BBBB',
+          status: 'created',
+          product: { id: 'prod_1' },
         },
       ],
       count: 30,
@@ -104,91 +104,85 @@ describe("Store license routes", () => {
     })
   })
 
-  it("returns license details", async () => {
+  it('returns license details', async () => {
     const data = [
       {
-        keygen_license_id: "lic_1",
-        license_key: "AAAA-BBBB",
-        status: "created",
-        keygen_product_id: "prod_1",
+        keygen_license_id: 'lic_1',
+        license_key: 'AAAA-BBBB',
+        status: 'created',
+        keygen_product_id: 'prod_1',
       },
     ]
     const query = { graph: vi.fn().mockResolvedValue({ data }) }
     const keygenService = {
       getLicenseWithMachines: vi.fn().mockResolvedValue({
-        id: "lic_1",
-        key: "AAAA-BBBB",
-        status: "active",
+        id: 'lic_1',
+        key: 'AAAA-BBBB',
+        status: 'active',
         maxMachines: 2,
-        machines: [{ id: "mach_1" }],
+        machines: [{ id: 'mach_1' }],
       }),
     }
     const req = {
-      params: { license_id: "lic_1" },
+      params: { license_id: 'lic_1' },
       scope: {
-        resolve: (k: string) =>
-          k === "query" ? query : k === "keygenService" ? keygenService : undefined,
+        resolve: (k: string) => (k === 'query' ? query : k === 'keygenService' ? keygenService : undefined),
       },
-      user: { id: "cust_1" },
+      user: { id: 'cust_1' },
     } as unknown as MedusaRequest
     const res = mockRes()
 
     await DETAIL(req, res)
 
-    expect(keygenService.getLicenseWithMachines).toHaveBeenCalledWith("lic_1")
+    expect(keygenService.getLicenseWithMachines).toHaveBeenCalledWith('lic_1')
     expect(res.json).toHaveBeenCalledWith({
       license: {
-        id: "lic_1",
-        key: "AAAA-BBBB",
-        status: "active",
-        product: { id: "prod_1" },
+        id: 'lic_1',
+        key: 'AAAA-BBBB',
+        status: 'active',
+        product: { id: 'prod_1' },
         max_machines: 2,
-        machines: [{ id: "mach_1" }],
+        machines: [{ id: 'mach_1' }],
       },
     })
   })
 
-  it("creates download link", async () => {
+  it('creates download link', async () => {
     const query = {
       graph: vi.fn().mockResolvedValue({
-        data: [{ keygen_license_id: "lic_1" }],
+        data: [{ keygen_license_id: 'lic_1' }],
       }),
     }
     const link = {
-      url: "https://s3.example.com/file",
-      expiresAt: "2030-01-01T00:00:00Z",
+      url: 'https://s3.example.com/file',
+      expiresAt: '2030-01-01T00:00:00Z',
       ttlSeconds: 900,
     }
     const keygenService = {
       createDownloadLink: vi.fn().mockResolvedValue(link),
     }
     const req = {
-      params: { license_id: "lic_1" },
-      body: { assetId: "asset_1" },
+      params: { license_id: 'lic_1' },
+      body: { assetId: 'asset_1' },
       scope: {
-        resolve: (k: string) =>
-          k === "query"
-            ? query
-            : k === "keygenService"
-            ? keygenService
-            : undefined,
+        resolve: (k: string) => (k === 'query' ? query : k === 'keygenService' ? keygenService : undefined),
       },
-      user: { id: "cust_1" },
+      user: { id: 'cust_1' },
     } as unknown as MedusaRequest
     const res = mockRes()
 
     await DOWNLOAD(req, res)
 
     expect(keygenService.createDownloadLink).toHaveBeenCalledWith({
-      licenseId: "lic_1",
-      assetId: "asset_1",
+      licenseId: 'lic_1',
+      assetId: 'asset_1',
       filename: undefined,
     })
     expect(res.status).toHaveBeenCalledWith(201)
     expect(res.json).toHaveBeenCalledWith({
       link,
-      licenseId: "lic_1",
-      assetId: "asset_1",
+      licenseId: 'lic_1',
+      assetId: 'asset_1',
     })
   })
 })

--- a/src/__tests__/routes.validate.test.ts
+++ b/src/__tests__/routes.validate.test.ts
@@ -1,5 +1,4 @@
-
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mockRes = () => {
   const r: any = {}
@@ -8,49 +7,51 @@ const mockRes = () => {
   return r
 }
 
-describe("Validate route", () => {
+describe('Validate route', () => {
   beforeEach(() => {
-    process.env.KEYGEN_ACCOUNT = "acct_123"
-    process.env.KEYGEN_TOKEN = "tok_123"
+    process.env.KEYGEN_ACCOUNT = 'acct_123'
+    process.env.KEYGEN_TOKEN = 'tok_123'
     delete process.env.KEYGEN_HOST
     vi.resetModules()
   })
 
-  it("validates a product id", async () => {
-    // @ts-ignore
+  it('validates a product id', async () => {
+    // @ts-expect-error mock fetch
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ data: { id: "prod_1", attributes: { name: "My Product" } } })
+      json: async () => ({ data: { id: 'prod_1', attributes: { name: 'My Product' } } }),
     })
 
-    const { POST: validate } = await import("../api/admin/keygen/validate/route")
-    const req: any = { body: { type: "product", id: "prod_1" } }
+    const { POST: validate } = await import('../api/admin/keygen/validate/route')
+    const req: any = { body: { type: 'product', id: 'prod_1' } }
     const res: any = mockRes()
 
     await validate(req, res)
     expect(global.fetch).toHaveBeenCalledWith(
-      "https://api.keygen.sh/v1/accounts/acct_123/products/prod_1",
+      'https://api.keygen.sh/v1/accounts/acct_123/products/prod_1',
       expect.objectContaining({
-        headers: expect.objectContaining({ "Keygen-Version": "1.8" })
-      })
+        headers: expect.objectContaining({ 'Keygen-Version': '1.8' }),
+      }),
     )
-    expect(res.json).toHaveBeenCalledWith({ id: "prod_1", type: "product", name: "My Product" })
+    expect(res.json).toHaveBeenCalledWith({ id: 'prod_1', type: 'product', name: 'My Product' })
   })
 
-  it("uses custom host from env", async () => {
-    process.env.KEYGEN_HOST = "https://custom.example.com"
+  it('uses custom host from env', async () => {
+    process.env.KEYGEN_HOST = 'https://custom.example.com'
     vi.resetModules()
-    // @ts-ignore
-    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: { id: "prod_1", attributes: { name: "A" } } }) })
-    const { POST: validate } = await import("../api/admin/keygen/validate/route")
-    const req: any = { body: { type: "product", id: "prod_1" } }
+    // @ts-expect-error mock fetch
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ data: { id: 'prod_1', attributes: { name: 'A' } } }) })
+    const { POST: validate } = await import('../api/admin/keygen/validate/route')
+    const req: any = { body: { type: 'product', id: 'prod_1' } }
     const res: any = mockRes()
     await validate(req, res)
     expect(global.fetch).toHaveBeenCalledWith(
-      "https://custom.example.com/v1/accounts/acct_123/products/prod_1",
+      'https://custom.example.com/v1/accounts/acct_123/products/prod_1',
       expect.objectContaining({
-        headers: expect.objectContaining({ "Keygen-Version": "1.8" })
-      })
+        headers: expect.objectContaining({ 'Keygen-Version': '1.8' }),
+      }),
     )
   })
 })

--- a/src/__tests__/service.activateMachine.test.ts
+++ b/src/__tests__/service.activateMachine.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-vi.mock("@medusajs/framework", () => ({
+vi.mock('@medusajs/framework', () => ({
   MedusaService: () => class {},
   ContainerRegistrationKeys: {},
 }))
 
-vi.mock("@medusajs/framework/utils", () => {
+vi.mock('@medusajs/framework/utils', () => {
   const chain = () => ({
     index: () => chain(),
     nullable: () => chain(),
@@ -19,67 +19,66 @@ vi.mock("@medusajs/framework/utils", () => {
 let KeygenService: any
 let container: any
 
-describe("KeygenService.activateMachine", () => {
+describe('KeygenService.activateMachine', () => {
   beforeEach(async () => {
-    process.env.KEYGEN_ACCOUNT = "acct_123"
-    process.env.KEYGEN_TOKEN = "tok_123"
+    process.env.KEYGEN_ACCOUNT = 'acct_123'
+    process.env.KEYGEN_TOKEN = 'tok_123'
     delete process.env.KEYGEN_HOST
     vi.resetModules()
-    KeygenService = (await import("../modules/keygen/service")).default
+    KeygenService = (await import('../modules/keygen/service')).default
     container = { resolve: () => ({}) }
   })
 
-  it("registers a machine when a seat is free", async () => {
+  it('registers a machine when a seat is free', async () => {
     // license
     const fetchMock = vi.fn()
     fetchMock
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ data: { id: "lic_1", attributes: { maxMachines: 3 } } }),
+        json: async () => ({ data: { id: 'lic_1', attributes: { maxMachines: 3 } } }),
       })
       // machines list
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ data: [{ id: "mac_1" }, { id: "mac_2" }] }),
+        json: async () => ({ data: [{ id: 'mac_1' }, { id: 'mac_2' }] }),
       })
       // machine create
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ data: { id: "mac_new" } }),
+        json: async () => ({ data: { id: 'mac_new' } }),
       })
-    // @ts-ignore
+    // @ts-expect-error mock fetch
     global.fetch = fetchMock
 
     const svc = new KeygenService(container, {})
     const result = await svc.activateMachine({
-      licenseId: "lic_1",
-      fingerprint: "fp_123",
+      licenseId: 'lic_1',
+      fingerprint: 'fp_123',
     })
 
-    expect(result.machineId).toBe("mac_new")
+    expect(result.machineId).toBe('mac_new')
     expect(result.seats).toEqual({ max: 3, used: 3 })
     expect(fetchMock).toHaveBeenCalledTimes(3)
   })
 
-  it("throws SeatsExhaustedError when no seats left", async () => {
+  it('throws SeatsExhaustedError when no seats left', async () => {
     const fetchMock = vi.fn()
     fetchMock
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ data: { id: "lic_1", attributes: { maxMachines: 2 } } }),
+        json: async () => ({ data: { id: 'lic_1', attributes: { maxMachines: 2 } } }),
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ data: [{ id: "mac_1" }, { id: "mac_2" }] }),
+        json: async () => ({ data: [{ id: 'mac_1' }, { id: 'mac_2' }] }),
       })
-    // @ts-ignore
+    // @ts-expect-error mock fetch
     global.fetch = fetchMock
 
     const svc = new KeygenService(container, {})
-    await expect(
-      svc.activateMachine({ licenseId: "lic_1", fingerprint: "fp" })
-    ).rejects.toMatchObject({ code: "SEATS_EXHAUSTED" })
+    await expect(svc.activateMachine({ licenseId: 'lic_1', fingerprint: 'fp' })).rejects.toMatchObject({
+      code: 'SEATS_EXHAUSTED',
+    })
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 })
-

--- a/src/__tests__/service.createLicense.test.ts
+++ b/src/__tests__/service.createLicense.test.ts
@@ -1,12 +1,11 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-import { describe, it, expect, vi, beforeEach } from "vitest"
-
-vi.mock("@medusajs/framework", () => ({
+vi.mock('@medusajs/framework', () => ({
   MedusaService: () => class {},
   ContainerRegistrationKeys: {},
 }))
 
-vi.mock("@medusajs/framework/utils", () => {
+vi.mock('@medusajs/framework/utils', () => {
   const chain = () => ({
     index: () => chain(),
     nullable: () => chain(),
@@ -21,24 +20,24 @@ let KeygenService: any
 let container: any
 let query: any
 
-describe("KeygenService.createLicense", () => {
+describe('KeygenService.createLicense', () => {
   beforeEach(async () => {
-    // @ts-ignore
+    // @ts-expect-error mock fetch
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: { id: "lic_123", attributes: { key: "AAAA-BBBB-CCCC" } }
-      })
+        data: { id: 'lic_123', attributes: { key: 'AAAA-BBBB-CCCC' } },
+      }),
     })
-    process.env.KEYGEN_ACCOUNT = "acct_123"
-    process.env.KEYGEN_TOKEN = "tok_123"
+    process.env.KEYGEN_ACCOUNT = 'acct_123'
+    process.env.KEYGEN_TOKEN = 'tok_123'
     delete process.env.KEYGEN_HOST
     vi.resetModules()
-    KeygenService = (await import("../modules/keygen/service")).default
+    KeygenService = (await import('../modules/keygen/service')).default
     query = { graph: vi.fn().mockResolvedValue({ data: [] }) }
     container = {
       resolve(key: string) {
-        if (key === "query") {
+        if (key === 'query') {
           return query
         }
         return undefined
@@ -46,14 +45,14 @@ describe("KeygenService.createLicense", () => {
     }
   })
 
-  it("creates a license and stores record", async () => {
+  it('creates a license and stores record', async () => {
     query.graph = vi.fn().mockResolvedValue({
       data: [
         {
-          id: "db_1",
-          order_id: "order_1",
-          license_key: "AAAA-BBBB-CCCC",
-          keygen_license_id: "lic_123",
+          id: 'db_1',
+          order_id: 'order_1',
+          license_key: 'AAAA-BBBB-CCCC',
+          keygen_license_id: 'lic_123',
         },
       ],
     })
@@ -61,93 +60,90 @@ describe("KeygenService.createLicense", () => {
     const svc = new (KeygenService as any)(container, {})
 
     const { record, raw } = await svc.createLicense({
-      orderId: "order_1",
-      orderItemId: "item_1",
-      policyId: "pol_1",
-      productId: "prod_1",
-      metadata: { foo: "bar" }
+      orderId: 'order_1',
+      orderItemId: 'item_1',
+      policyId: 'pol_1',
+      productId: 'prod_1',
+      metadata: { foo: 'bar' },
     })
 
     expect(global.fetch).toHaveBeenCalledWith(
-      "https://api.keygen.sh/v1/accounts/acct_123/licenses",
+      'https://api.keygen.sh/v1/accounts/acct_123/licenses',
       expect.objectContaining({
-        headers: expect.objectContaining({ "Keygen-Version": "1.8" })
-      })
+        headers: expect.objectContaining({ 'Keygen-Version': '1.8' }),
+      }),
     )
-    expect(record.license_key).toBe("AAAA-BBBB-CCCC")
-    expect(raw.data.id).toBe("lic_123")
+    expect(record.license_key).toBe('AAAA-BBBB-CCCC')
+    expect(raw.data.id).toBe('lic_123')
   })
 
-
-
-  it("uses custom host from env", async () => {
-    process.env.KEYGEN_HOST = "https://custom.example.com"
+  it('uses custom host from env', async () => {
+    process.env.KEYGEN_HOST = 'https://custom.example.com'
     vi.resetModules()
-    KeygenService = (await import("../modules/keygen/service")).default
+    KeygenService = (await import('../modules/keygen/service')).default
     const svc = new (KeygenService as any)(container, {})
     svc.createKeygenLicenses = vi.fn().mockResolvedValue({ data: [] })
-    await svc.createLicense({ orderId: "order_1" })
+    await svc.createLicense({ orderId: 'order_1' })
 
     expect(global.fetch).toHaveBeenCalledWith(
-      "https://custom.example.com/v1/accounts/acct_123/licenses",
+      'https://custom.example.com/v1/accounts/acct_123/licenses',
       expect.objectContaining({
-        headers: expect.objectContaining({ "Keygen-Version": "1.8" })
-      })
+        headers: expect.objectContaining({ 'Keygen-Version': '1.8' }),
+      }),
     )
   })
 
-  it("throws a descriptive error on network failure", async () => {
-    global.fetch = vi.fn().mockRejectedValue(new Error("Network down"))
+  it('throws a descriptive error on network failure', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('Network down'))
     const svc = new (KeygenService as any)(container, {})
 
+    await expect(svc.createLicense({ orderId: 'order_1' })).rejects.toThrow(
+      '[keygen] create license request failed: Network down',
+    )
+  })
 
-      await expect(svc.createLicense({ orderId: "order_1" })).rejects.toThrow(
-        "[keygen] create license request failed: Network down"
-      )
-    })
-
-    it("retries on temporary server error", async () => {
-      vi.useFakeTimers()
-      global.fetch = vi
-        .fn()
-        .mockResolvedValueOnce({
-          ok: false,
-          status: 500,
-          statusText: "err",
-          text: async () => "",
-        })
-        .mockResolvedValueOnce({
-          ok: false,
-          status: 502,
-          statusText: "err",
-          text: async () => "",
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            data: { id: "lic_retry", attributes: { key: "FFFF-GGGG-HHHH" } },
-          }),
-        })
-
-      query.graph = vi.fn().mockResolvedValue({
-        data: [
-          {
-            id: "db_retry",
-            order_id: "order_1",
-            license_key: "FFFF-GGGG-HHHH",
-            keygen_license_id: "lic_retry",
-          },
-        ],
+  it('retries on temporary server error', async () => {
+    vi.useFakeTimers()
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'err',
+        text: async () => '',
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        statusText: 'err',
+        text: async () => '',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: { id: 'lic_retry', attributes: { key: 'FFFF-GGGG-HHHH' } },
+        }),
       })
 
-      const svc = new (KeygenService as any)(container, {})
-
-      const promise = svc.createLicense({ orderId: "order_1" })
-      await vi.runAllTimersAsync()
-      const result = await promise
-
-      expect(global.fetch).toHaveBeenCalledTimes(3)
-      expect(result.raw.data.id).toBe("lic_retry")
-      vi.useRealTimers()
+    query.graph = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'db_retry',
+          order_id: 'order_1',
+          license_key: 'FFFF-GGGG-HHHH',
+          keygen_license_id: 'lic_retry',
+        },
+      ],
     })
+
+    const svc = new (KeygenService as any)(container, {})
+
+    const promise = svc.createLicense({ orderId: 'order_1' })
+    await vi.runAllTimersAsync()
+    const result = await promise
+
+    expect(global.fetch).toHaveBeenCalledTimes(3)
+    expect(result.raw.data.id).toBe('lic_retry')
+    vi.useRealTimers()
   })
+})

--- a/src/__tests__/subscriber.orderCanceled.test.ts
+++ b/src/__tests__/subscriber.orderCanceled.test.ts
@@ -1,15 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-vi.mock("@medusajs/framework", () => ({
+vi.mock('@medusajs/framework', () => ({
   MedusaService: () => class {},
   ContainerRegistrationKeys: {
-    LOGGER: "logger",
-    CONFIG_MODULE: "config",
-    QUERY: "query",
+    LOGGER: 'logger',
+    CONFIG_MODULE: 'config',
+    QUERY: 'query',
   },
 }))
 
-vi.mock("@medusajs/framework/utils", () => {
+vi.mock('@medusajs/framework/utils', () => {
   const chain = () => ({
     index: () => chain(),
     nullable: () => chain(),
@@ -20,7 +20,7 @@ vi.mock("@medusajs/framework/utils", () => {
   return { model: { define: vi.fn(() => ({})), text: chain, id: chain, enum: chain } }
 })
 
-import { ContainerRegistrationKeys } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from '@medusajs/framework'
 let orderCanceledSubscriber: any
 let KeygenService: any
 
@@ -33,10 +33,10 @@ const buildContainer = () => {
     resolve(key: string) {
       switch (key) {
         case ContainerRegistrationKeys.LOGGER:
-        case "logger":
+        case 'logger':
           return logger
         case ContainerRegistrationKeys.QUERY:
-        case "query":
+        case 'query':
           return query
         case KeygenService.registrationName:
           return keygen
@@ -49,50 +49,45 @@ const buildContainer = () => {
   return { container, logger, query, keygen }
 }
 
-describe("orderCanceledSubscriber", () => {
+describe('orderCanceledSubscriber', () => {
   beforeEach(async () => {
-    process.env.KEYGEN_ACCOUNT = "acct_123"
-    process.env.KEYGEN_TOKEN = "tok_123"
+    process.env.KEYGEN_ACCOUNT = 'acct_123'
+    process.env.KEYGEN_TOKEN = 'tok_123'
     delete process.env.KEYGEN_HOST
     vi.resetModules()
-    ;({ default: orderCanceledSubscriber } = await import("../subscribers/order-canceled"))
-    KeygenService = (await import("../modules/keygen/service")).default
+    ;({ default: orderCanceledSubscriber } = await import('../subscribers/order-canceled'))
+    KeygenService = (await import('../modules/keygen/service')).default
   })
 
-  it("suspends licenses for canceled order", async () => {
+  it('suspends licenses for canceled order', async () => {
     const { container, logger, query, keygen } = buildContainer()
     query.graph = vi
       .fn()
       .mockResolvedValueOnce({
-        data: [
-          { id: "db_1", keygen_license_id: "lic_1", order_item_id: "item_1" },
-        ],
+        data: [{ id: 'db_1', keygen_license_id: 'lic_1', order_item_id: 'item_1' }],
       })
       .mockResolvedValue({ data: [] })
 
     await orderCanceledSubscriber({
       container: container as any,
-      event: { name: "order.canceled", data: { id: "order_1" } } as any,
+      event: { name: 'order.canceled', data: { id: 'order_1' } } as any,
     })
 
-    expect(keygen.suspendLicense).toHaveBeenCalledWith("lic_1")
+    expect(keygen.suspendLicense).toHaveBeenCalledWith('lic_1')
     expect(query.graph).toHaveBeenLastCalledWith({
-      entity: "keygen_license",
-      data: [{ id: "db_1", status: "suspended" }],
+      entity: 'keygen_license',
+      data: [{ id: 'db_1', status: 'suspended' }],
     })
-    expect(logger.info).toHaveBeenCalledWith(
-      "[keygen] license suspended for order order_1 / item item_1: lic_1"
-    )
+    expect(logger.info).toHaveBeenCalledWith('[keygen] license suspended for order order_1 / item item_1: lic_1')
   })
 
-  it("ignores non order canceled events", async () => {
+  it('ignores non order canceled events', async () => {
     const { container, logger, keygen } = buildContainer()
     await orderCanceledSubscriber({
       container: container as any,
-      event: { name: "order.updated", data: { id: "order_1" } } as any,
+      event: { name: 'order.updated', data: { id: 'order_1' } } as any,
     })
     expect(keygen.suspendLicense).not.toHaveBeenCalled()
     expect(logger.info).not.toHaveBeenCalled()
   })
 })
-

--- a/src/__tests__/subscriber.orderPlaced.test.ts
+++ b/src/__tests__/subscriber.orderPlaced.test.ts
@@ -1,15 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-vi.mock("@medusajs/framework", () => ({
+vi.mock('@medusajs/framework', () => ({
   MedusaService: () => class {},
   ContainerRegistrationKeys: {
-    LOGGER: "logger",
-    CONFIG_MODULE: "config",
-    QUERY: "query",
+    LOGGER: 'logger',
+    CONFIG_MODULE: 'config',
+    QUERY: 'query',
   },
 }))
 
-vi.mock("@medusajs/framework/utils", () => {
+vi.mock('@medusajs/framework/utils', () => {
   const chain = () => ({
     index: () => chain(),
     nullable: () => chain(),
@@ -20,27 +20,27 @@ vi.mock("@medusajs/framework/utils", () => {
   return { model: { define: vi.fn(() => ({})), text: chain, id: chain, enum: chain } }
 })
 
-import { ContainerRegistrationKeys } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from '@medusajs/framework'
 let orderPlacedSubscriber: any
 let KeygenService: any
 
 const buildContainer = () => {
   const logger = { info: vi.fn(), error: vi.fn() }
-  const keygen = { createLicense: vi.fn().mockResolvedValue({ record: { license_key: "AAAA" } }) }
+  const keygen = { createLicense: vi.fn().mockResolvedValue({ record: { license_key: 'AAAA' } }) }
   const order = {
-    id: "order_1",
-    customer_id: "cust_1",
+    id: 'order_1',
+    customer_id: 'cust_1',
     items: [
       {
-        id: "item_1",
-        variant_id: "var_1",
-        metadata: { policy: "pol_1", product: "prod_1" },
+        id: 'item_1',
+        variant_id: 'var_1',
+        metadata: { policy: 'pol_1', product: 'prod_1' },
       },
     ],
   }
   const query = { graph: vi.fn().mockResolvedValue({ data: [order] }) }
-  const options = { policyMetadataKey: "policy", productMetadataKey: "product" }
-  const config = { plugins: [{ resolve: "medusa-plugin-keygen", options }] }
+  const options = { policyMetadataKey: 'policy', productMetadataKey: 'product' }
+  const config = { plugins: [{ resolve: 'medusa-plugin-keygen', options }] }
 
   const container = {
     resolve(key: string) {
@@ -48,7 +48,7 @@ const buildContainer = () => {
         case ContainerRegistrationKeys.LOGGER:
           return logger
         case ContainerRegistrationKeys.CONFIG_MODULE:
-        case "configModule":
+        case 'configModule':
           return config
         case ContainerRegistrationKeys.QUERY:
           return query
@@ -63,44 +63,42 @@ const buildContainer = () => {
   return { container, logger, keygen, query }
 }
 
-describe("orderPlacedSubscriber", () => {
+describe('orderPlacedSubscriber', () => {
   beforeEach(async () => {
-    process.env.KEYGEN_ACCOUNT = "acct_123"
-    process.env.KEYGEN_TOKEN = "tok_123"
+    process.env.KEYGEN_ACCOUNT = 'acct_123'
+    process.env.KEYGEN_TOKEN = 'tok_123'
     delete process.env.KEYGEN_HOST
     vi.resetModules()
-    ;({ default: orderPlacedSubscriber } = await import("../subscribers/order-placed"))
-    KeygenService = (await import("../modules/keygen/service")).default
+    ;({ default: orderPlacedSubscriber } = await import('../subscribers/order-placed'))
+    KeygenService = (await import('../modules/keygen/service')).default
   })
 
-  it("creates license for items with metadata", async () => {
+  it('creates license for items with metadata', async () => {
     const { container, logger, keygen } = buildContainer()
     await orderPlacedSubscriber({
       container: container as any,
-      event: { name: "order.placed", data: { id: "order_1" } } as any,
+      event: { name: 'order.placed', data: { id: 'order_1' } } as any,
     })
     expect(keygen.createLicense).toHaveBeenCalledWith({
-      orderId: "order_1",
-      orderItemId: "item_1",
-      customerId: "cust_1",
-      policyId: "pol_1",
-      productId: "prod_1",
+      orderId: 'order_1',
+      orderItemId: 'item_1',
+      customerId: 'cust_1',
+      policyId: 'pol_1',
+      productId: 'prod_1',
       metadata: {
-        orderId: "order_1",
-        orderItemId: "item_1",
-        variantId: "var_1",
+        orderId: 'order_1',
+        orderItemId: 'item_1',
+        variantId: 'var_1',
       },
     })
-    expect(logger.info).toHaveBeenCalledWith(
-      `[keygen] license created for order order_1 / item item_1: AAAA`
-    )
+    expect(logger.info).toHaveBeenCalledWith(`[keygen] license created for order order_1 / item item_1: AAAA`)
   })
 
-  it("ignores non order placed events", async () => {
+  it('ignores non order placed events', async () => {
     const { container, keygen, logger } = buildContainer()
     await orderPlacedSubscriber({
       container: container as any,
-      event: { name: "order.updated", data: { id: "order_1" } } as any,
+      event: { name: 'order.updated', data: { id: 'order_1' } } as any,
     })
     expect(keygen.createLicense).not.toHaveBeenCalled()
     expect(logger.info).not.toHaveBeenCalled()

--- a/src/__tests__/subscriber.orderRefunded.test.ts
+++ b/src/__tests__/subscriber.orderRefunded.test.ts
@@ -1,15 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-vi.mock("@medusajs/framework", () => ({
+vi.mock('@medusajs/framework', () => ({
   MedusaService: () => class {},
   ContainerRegistrationKeys: {
-    LOGGER: "logger",
-    CONFIG_MODULE: "config",
-    QUERY: "query",
+    LOGGER: 'logger',
+    CONFIG_MODULE: 'config',
+    QUERY: 'query',
   },
 }))
 
-vi.mock("@medusajs/framework/utils", () => {
+vi.mock('@medusajs/framework/utils', () => {
   const chain = () => ({
     index: () => chain(),
     nullable: () => chain(),
@@ -20,7 +20,7 @@ vi.mock("@medusajs/framework/utils", () => {
   return { model: { define: vi.fn(() => ({})), text: chain, id: chain, enum: chain } }
 })
 
-import { ContainerRegistrationKeys } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from '@medusajs/framework'
 let KeygenService: any
 let orderRefundedSubscriber: any
 
@@ -33,10 +33,10 @@ const buildContainer = () => {
     resolve(key: string) {
       switch (key) {
         case ContainerRegistrationKeys.LOGGER:
-        case "logger":
+        case 'logger':
           return logger
         case ContainerRegistrationKeys.QUERY:
-        case "query":
+        case 'query':
           return query
         case KeygenService.registrationName:
           return keygen
@@ -49,47 +49,43 @@ const buildContainer = () => {
   return { container, logger, query, keygen }
 }
 
-describe("orderRefundedSubscriber", () => {
+describe('orderRefundedSubscriber', () => {
   beforeEach(async () => {
     vi.resetModules()
-    process.env.KEYGEN_ACCOUNT = "acct_123"
-    process.env.KEYGEN_TOKEN = "tok_123"
+    process.env.KEYGEN_ACCOUNT = 'acct_123'
+    process.env.KEYGEN_TOKEN = 'tok_123'
     delete process.env.KEYGEN_HOST
-    KeygenService = (await import("../modules/keygen/service")).default
-    orderRefundedSubscriber = (await import("../subscribers/order-refunded")).default
+    KeygenService = (await import('../modules/keygen/service')).default
+    orderRefundedSubscriber = (await import('../subscribers/order-refunded')).default
   })
 
-  it("revokes licenses for refunded order", async () => {
+  it('revokes licenses for refunded order', async () => {
     const { container, logger, query, keygen } = buildContainer()
     query.graph = vi
       .fn()
       .mockResolvedValueOnce({
-        data: [
-          { id: "db_1", keygen_license_id: "lic_1", order_item_id: "item_1" },
-        ],
+        data: [{ id: 'db_1', keygen_license_id: 'lic_1', order_item_id: 'item_1' }],
       })
       .mockResolvedValue({ data: [] })
 
     await orderRefundedSubscriber({
       container: container as any,
-      event: { name: "order.refunded", data: { id: "order_1" } } as any,
+      event: { name: 'order.refunded', data: { id: 'order_1' } } as any,
     })
 
-    expect(keygen.revokeLicense).toHaveBeenCalledWith("lic_1")
+    expect(keygen.revokeLicense).toHaveBeenCalledWith('lic_1')
     expect(query.graph).toHaveBeenLastCalledWith({
-      entity: "keygen_license",
-      data: [{ id: "db_1", status: "revoked" }],
+      entity: 'keygen_license',
+      data: [{ id: 'db_1', status: 'revoked' }],
     })
-    expect(logger.info).toHaveBeenCalledWith(
-      "[keygen] license revoked for order order_1 / item item_1: lic_1"
-    )
+    expect(logger.info).toHaveBeenCalledWith('[keygen] license revoked for order order_1 / item item_1: lic_1')
   })
 
-  it("ignores non order refunded events", async () => {
+  it('ignores non order refunded events', async () => {
     const { container, logger, keygen } = buildContainer()
     await orderRefundedSubscriber({
       container: container as any,
-      event: { name: "order.updated", data: { id: "order_1" } } as any,
+      event: { name: 'order.updated', data: { id: 'order_1' } } as any,
     })
     expect(keygen.revokeLicense).not.toHaveBeenCalled()
     expect(logger.info).not.toHaveBeenCalled()

--- a/src/__tests__/validate-route.test.ts
+++ b/src/__tests__/validate-route.test.ts
@@ -1,30 +1,30 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 let POST: any
 
-describe("validate route", () => {
+describe('validate route', () => {
   beforeEach(async () => {
-    process.env.KEYGEN_ACCOUNT = "acc"
-    process.env.KEYGEN_TOKEN = "tok"
-    process.env.KEYGEN_VERSION = "1.8"
+    process.env.KEYGEN_ACCOUNT = 'acc'
+    process.env.KEYGEN_TOKEN = 'tok'
+    process.env.KEYGEN_VERSION = '1.8'
     vi.resetModules()
-    POST = (await import("../api/admin/keygen/validate/route")).POST
+    POST = (await import('../api/admin/keygen/validate/route')).POST
   })
 
-  it("returns generic message on upstream error", async () => {
-    const req: any = { body: { type: "product", id: "123" } }
+  it('returns generic message on upstream error', async () => {
+    const req: any = { body: { type: 'product', id: '123' } }
     const res: any = { status: vi.fn().mockReturnThis(), json: vi.fn() }
 
     global.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 404,
-      statusText: "Not Found",
-      text: vi.fn().mockResolvedValue("sensitive error"),
+      statusText: 'Not Found',
+      text: vi.fn().mockResolvedValue('sensitive error'),
     }) as any
 
     await POST(req, res)
 
     expect(res.status).toHaveBeenCalledWith(404)
-    expect(res.json).toHaveBeenCalledWith({ message: "Validation failed" })
+    expect(res.json).toHaveBeenCalledWith({ message: 'Validation failed' })
     expect(global.fetch).toHaveBeenCalled()
   })
 })

--- a/src/admin/utils/keygen.ts
+++ b/src/admin/utils/keygen.ts
@@ -1,6 +1,6 @@
 export const loadRecent = (key: string): string[] => {
   try {
-    return JSON.parse(localStorage.getItem(key) || "[]")
+    return JSON.parse(localStorage.getItem(key) || '[]')
   } catch {
     return []
   }
@@ -19,19 +19,16 @@ export interface ValidationResponse {
   message?: string
 }
 
-export async function validateOnServer(
-  type: "product" | "policy",
-  id: string
-): Promise<ValidationResponse> {
-  if (!id) return { ok: false, message: "ID missing" }
+export async function validateOnServer(type: 'product' | 'policy', id: string): Promise<ValidationResponse> {
+  if (!id) return { ok: false, message: 'ID missing' }
   const res = await fetch(`/admin/keygen/validate`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ type, id }),
-    credentials: "include",
+    credentials: 'include',
   })
   if (!res.ok) {
-    const t = await res.text().catch(() => "")
+    const t = await res.text().catch(() => '')
     return { ok: false, message: `Error ${res.status}: ${t}` }
   }
   const json = await res.json()

--- a/src/admin/widgets/keygen-customer.tsx
+++ b/src/admin/widgets/keygen-customer.tsx
@@ -1,7 +1,7 @@
-import { defineWidgetConfig } from "@medusajs/admin-sdk"
-import type { DetailWidgetProps, AdminCustomer } from "@medusajs/framework/types"
-import { Container, Heading, Text, Button } from "@medusajs/ui"
-import { useEffect, useState } from "react"
+import { defineWidgetConfig } from '@medusajs/admin-sdk'
+import type { DetailWidgetProps, AdminCustomer } from '@medusajs/framework/types'
+import { Container, Heading, Text, Button } from '@medusajs/ui'
+import { useEffect, useState } from 'react'
 
 type Machine = { id: string; name?: string | null; fingerprint?: string | null; platform?: string | null }
 type License = {
@@ -19,7 +19,7 @@ const KeygenCustomerWidget = ({ data }: DetailWidgetProps<AdminCustomer>) => {
   const load = async () => {
     if (!customerId) return
     const res = await fetch(`/admin/keygen/customers/${customerId}/licenses`, {
-      credentials: "include",
+      credentials: 'include',
     })
     if (!res.ok) return
     const json = await res.json()
@@ -32,8 +32,8 @@ const KeygenCustomerWidget = ({ data }: DetailWidgetProps<AdminCustomer>) => {
 
   async function unbind(machineId: string) {
     await fetch(`/admin/keygen/machines/${machineId}`, {
-      method: "DELETE",
-      credentials: "include",
+      method: 'DELETE',
+      credentials: 'include',
     })
     await load()
   }
@@ -60,11 +60,7 @@ const KeygenCustomerWidget = ({ data }: DetailWidgetProps<AdminCustomer>) => {
                 {lic.machines.map((m) => (
                   <div key={m.id} className="flex items-center gap-2">
                     <Text>{m.name || m.fingerprint || m.id}</Text>
-                    <Button
-                      size="small"
-                      variant="secondary"
-                      onClick={() => unbind(m.id)}
-                    >
+                    <Button size="small" variant="secondary" onClick={() => unbind(m.id)}>
                       Unbind
                     </Button>
                   </div>
@@ -81,7 +77,7 @@ const KeygenCustomerWidget = ({ data }: DetailWidgetProps<AdminCustomer>) => {
 }
 
 export const config = defineWidgetConfig({
-  zone: "customer.details.after",
+  zone: 'customer.details.after',
 })
 
 export default KeygenCustomerWidget

--- a/src/admin/widgets/keygen-product.tsx
+++ b/src/admin/widgets/keygen-product.tsx
@@ -1,24 +1,23 @@
+import { defineWidgetConfig } from '@medusajs/admin-sdk'
+import type { DetailWidgetProps, AdminProduct } from '@medusajs/framework/types'
+import { Container, Heading, Input, Button, Label, Text, Switch, Badge, Checkbox } from '@medusajs/ui'
+import { useState, useMemo, useEffect } from 'react'
+import { loadRecent, pushRecent, validateOnServer, ValidationResponse } from '../utils/keygen'
 
-import { defineWidgetConfig } from "@medusajs/admin-sdk"
-import type { DetailWidgetProps, AdminProduct } from "@medusajs/framework/types"
-import { Container, Heading, Input, Button, Label, Text, Switch, Badge, Checkbox } from "@medusajs/ui"
-import { useState, useMemo, useEffect } from "react"
-import { loadRecent, pushRecent, validateOnServer, ValidationResponse } from "../utils/keygen"
-
-const LS_RECENT_PRODUCTS = "keygen_recent_products"
-const LS_RECENT_POLICIES = "keygen_recent_policies"
+const LS_RECENT_PRODUCTS = 'keygen_recent_products'
+const LS_RECENT_POLICIES = 'keygen_recent_policies'
 
 async function listPolicies(productId: string) {
   const url = new URL(`/admin/keygen/policies`, window.location.origin)
-  if (productId) url.searchParams.set("productId", productId)
-  const res = await fetch(url.toString(), { credentials: "include" })
+  if (productId) url.searchParams.set('productId', productId)
+  const res = await fetch(url.toString(), { credentials: 'include' })
   if (!res.ok) return []
   const json = await res.json()
   return (json?.data ?? []) as { id: string; name?: string }[]
 }
 
 async function listEntitlements() {
-  const res = await fetch(`/admin/keygen/entitlements`, { credentials: "include" })
+  const res = await fetch(`/admin/keygen/entitlements`, { credentials: 'include' })
   if (!res.ok) return []
   const json = await res.json()
   return (json?.data ?? []) as { id: string; code?: string; name?: string }[]
@@ -33,13 +32,13 @@ async function createPolicyServer(payload: {
   entitlementIds?: string[]
 }): Promise<{ id?: string }> {
   const res = await fetch(`/admin/keygen/policies`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
-    credentials: "include",
+    credentials: 'include',
   })
   if (!res.ok) {
-    const t = await res.text().catch(() => "")
+    const t = await res.text().catch(() => '')
     throw new Error(`Policy create failed: ${res.status} ${t}`)
   }
   return await res.json()
@@ -57,30 +56,27 @@ async function clonePolicyServer(payload: {
   }
 }): Promise<{ id?: string }> {
   const res = await fetch(`/admin/keygen/policies/clone`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
-    credentials: "include",
+    credentials: 'include',
   })
   if (!res.ok) {
-    const t = await res.text().catch(() => "")
+    const t = await res.text().catch(() => '')
     throw new Error(`Policy clone failed: ${res.status} ${t}`)
   }
   return await res.json()
 }
 
-async function patchProductMetadata(
-  productId: string,
-  meta: Record<string, unknown>
-) {
+async function patchProductMetadata(productId: string, meta: Record<string, unknown>) {
   const res = await fetch(`/admin/products/${productId}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "include",
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
     body: JSON.stringify({ metadata: meta }),
   })
   if (!res.ok) {
-    const t = await res.text().catch(() => "")
+    const t = await res.text().catch(() => '')
     throw new Error(`Update failed: ${res.status} ${t}`)
   }
   return await res.json()
@@ -88,34 +84,36 @@ async function patchProductMetadata(
 
 const KeygenProductWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
   const currentMeta = data?.metadata ?? {}
-  const productDisplayName = data?.title ?? data?.handle ?? ""
-  const [kp, setKp] = useState<string>(String(currentMeta["keygen_product"] ?? ""))
-  const [kl, setKl] = useState<string>(String(currentMeta["keygen_policy"] ?? ""))
+  const productDisplayName = data?.title ?? data?.handle ?? ''
+  const [kp, setKp] = useState<string>(String(currentMeta['keygen_product'] ?? ''))
+  const [kl, setKl] = useState<string>(String(currentMeta['keygen_policy'] ?? ''))
   const [autoValidate, setAutoValidate] = useState(true)
-  const [vp, setVp] = useState<{ok:boolean;message?:string;name?:string}|null>(null)
-  const [vl, setVl] = useState<{ok:boolean;message?:string;name?:string}|null>(null)
-  const canSave = useMemo(() => kp !== String(currentMeta["keygen_product"] ?? "") ||
-                                  kl !== String(currentMeta["keygen_policy"] ?? ""), [kp, kl, currentMeta])
+  const [vp, setVp] = useState<{ ok: boolean; message?: string; name?: string } | null>(null)
+  const [vl, setVl] = useState<{ ok: boolean; message?: string; name?: string } | null>(null)
+  const canSave = useMemo(
+    () => kp !== String(currentMeta['keygen_product'] ?? '') || kl !== String(currentMeta['keygen_policy'] ?? ''),
+    [kp, kl, currentMeta],
+  )
 
   const [recentProducts, setRecentProducts] = useState<string[]>([])
   const [recentPolicies, setRecentPolicies] = useState<string[]>([])
 
-  const [policies, setPolicies] = useState<{id:string;name?:string}[]>([])
-  const [entitlements, setEntitlements] = useState<{id:string;code?:string;name?:string}[]>([])
+  const [policies, setPolicies] = useState<{ id: string; name?: string }[]>([])
+  const [entitlements, setEntitlements] = useState<{ id: string; code?: string; name?: string }[]>([])
   const [selectedEntitlements, setSelectedEntitlements] = useState<string[]>([])
 
-  const [baseName, setBaseName] = useState("Annual")
+  const [baseName, setBaseName] = useState('Annual')
   const [seats, setSeats] = useState<number>(2)
   const [floating, setFloating] = useState<boolean>(false)
   const [durationDays, setDurationDays] = useState<number>(365)
   const [autoName, setAutoName] = useState(true)
 
-  const [cloneSourceId, setCloneSourceId] = useState("")
-  const [cloneTargetProductId, setCloneTargetProductId] = useState("")
-  const [cloneOverrideName, setCloneOverrideName] = useState("")
-  const [cloneOverrideSeats, setCloneOverrideSeats] = useState<number|undefined>(undefined)
-  const [cloneOverrideFloating, setCloneOverrideFloating] = useState<boolean|undefined>(undefined)
-  const [cloneOverrideDurationDays, setCloneOverrideDurationDays] = useState<number|undefined>(undefined)
+  const [cloneSourceId, setCloneSourceId] = useState('')
+  const [cloneTargetProductId, setCloneTargetProductId] = useState('')
+  const [cloneOverrideName, setCloneOverrideName] = useState('')
+  const [cloneOverrideSeats, setCloneOverrideSeats] = useState<number | undefined>(undefined)
+  const [cloneOverrideFloating, setCloneOverrideFloating] = useState<boolean | undefined>(undefined)
+  const [cloneOverrideDurationDays, setCloneOverrideDurationDays] = useState<number | undefined>(undefined)
 
   useEffect(() => {
     setRecentProducts(loadRecent(LS_RECENT_PRODUCTS))
@@ -124,34 +122,30 @@ const KeygenProductWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
 
   useEffect(() => {
     if (kp) {
-      listPolicies(kp).then(setPolicies).catch(() => setPolicies([]))
-      listEntitlements().then(setEntitlements).catch(() => setEntitlements([]))
+      listPolicies(kp)
+        .then(setPolicies)
+        .catch(() => setPolicies([]))
+      listEntitlements()
+        .then(setEntitlements)
+        .catch(() => setEntitlements([]))
     } else {
       setPolicies([])
     }
   }, [kp])
 
-  const generatedName = `${productDisplayName ? productDisplayName + " – " : ""}${baseName} – ${seats} Seats${floating ? " (Floating)" : ""}${durationDays ? " – " + durationDays + "d" : ""}`
+  const generatedName = `${productDisplayName ? productDisplayName + ' – ' : ''}${baseName} – ${seats} Seats${floating ? ' (Floating)' : ''}${durationDays ? ' – ' + durationDays + 'd' : ''}`
 
   async function handleValidate() {
-    const resP: ValidationResponse = kp
-      ? await validateOnServer("product", kp)
-      : { ok: true }
-    const resL: ValidationResponse = kl
-      ? await validateOnServer("policy", kl)
-      : { ok: true }
+    const resP: ValidationResponse = kp ? await validateOnServer('product', kp) : { ok: true }
+    const resL: ValidationResponse = kl ? await validateOnServer('policy', kl) : { ok: true }
     setVp(resP.ok ? { ok: true, name: resP.data?.name } : { ok: false, message: resP.message })
     setVl(resL.ok ? { ok: true, name: resL.data?.name } : { ok: false, message: resL.message })
   }
 
   async function handleSave() {
     if (autoValidate) {
-      const resP: ValidationResponse = kp
-        ? await validateOnServer("product", kp)
-        : { ok: true }
-      const resL: ValidationResponse = kl
-        ? await validateOnServer("policy", kl)
-        : { ok: true }
+      const resP: ValidationResponse = kp ? await validateOnServer('product', kp) : { ok: true }
+      const resL: ValidationResponse = kl ? await validateOnServer('policy', kl) : { ok: true }
       if (!resP.ok || !resL.ok) {
         setVp(resP.ok ? { ok: true, name: resP.data?.name } : { ok: false, message: resP.message })
         setVl(resL.ok ? { ok: true, name: resL.data?.name } : { ok: false, message: resL.message })
@@ -170,14 +164,12 @@ const KeygenProductWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
   }
 
   function toggleEntitlement(id: string) {
-    setSelectedEntitlements((prev) =>
-      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
-    )
+    setSelectedEntitlements((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
   }
 
   async function handleCreatePolicyAdvanced() {
     if (!kp) {
-      alert("Please enter a Keygen Product ID (keygen_product) first.")
+      alert('Please enter a Keygen Product ID (keygen_product) first.')
       return
     }
     const name = autoName ? generatedName : `${baseName}`
@@ -195,13 +187,15 @@ const KeygenProductWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
       setKl(newId)
       setVl({ ok: true, name })
       pushRecent(LS_RECENT_POLICIES, newId)
-      listPolicies(kp).then(setPolicies).catch(() => {})
+      listPolicies(kp)
+        .then(setPolicies)
+        .catch(() => {})
     }
   }
 
   async function handleClonePolicy() {
     if (!cloneSourceId || !cloneTargetProductId) {
-      alert("Please provide source policy and target product ID.")
+      alert('Please provide source policy and target product ID.')
       return
     }
     const overrides: Record<string, unknown> = {}
@@ -213,12 +207,14 @@ const KeygenProductWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
     const resp = await clonePolicyServer({
       sourcePolicyId: cloneSourceId,
       targetProductId: cloneTargetProductId,
-      overrides: Object.keys(overrides).length ? overrides : undefined
+      overrides: Object.keys(overrides).length ? overrides : undefined,
     })
     const newId = resp?.id
     if (newId) {
       if (cloneTargetProductId === kp) {
-        listPolicies(kp).then(setPolicies).catch(() => {})
+        listPolicies(kp)
+          .then(setPolicies)
+          .catch(() => {})
       }
       setKl(newId)
       pushRecent(LS_RECENT_POLICIES, newId)
@@ -237,12 +233,14 @@ const KeygenProductWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
         <div>
           <Label>Keygen Product ID (keygen_product)</Label>
           <Input placeholder="prod_XXXX" value={kp} onChange={(e) => setKp(e.target.value)} />
-          {vp?.ok && kp && <Text className="mt-1">✅ Found: {vp.name ?? "OK"}</Text>}
+          {vp?.ok && kp && <Text className="mt-1">✅ Found: {vp.name ?? 'OK'}</Text>}
           {vp?.ok === false && <Text className="mt-1 text-ui-fg-error">❌ {vp.message}</Text>}
           {recentProducts.length > 0 && (
             <div className="mt-2 flex flex-wrap gap-2">
               {recentProducts.map((id) => (
-                <Badge key={id} onClick={() => setKp(id)} variant="secondary">{id}</Badge>
+                <Badge key={id} onClick={() => setKp(id)} variant="secondary">
+                  {id}
+                </Badge>
               ))}
             </div>
           )}
@@ -251,22 +249,24 @@ const KeygenProductWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
         <div>
           <Label>Keygen Policy ID (keygen_policy)</Label>
           <Input placeholder="pol_XXXX" value={kl} onChange={(e) => setKl(e.target.value)} />
-          {vl?.ok && kl && <Text className="mt-1">✅ Found: {vl.name ?? "OK"}</Text>}
+          {vl?.ok && kl && <Text className="mt-1">✅ Found: {vl.name ?? 'OK'}</Text>}
           {vl?.ok === false && <Text className="mt-1 text-ui-fg-error">❌ {vl.message}</Text>}
           {recentPolicies.length > 0 && (
             <div className="mt-2 flex flex-wrap gap-2">
               {recentPolicies.map((id) => (
-                <Badge key={id} onClick={() => setKl(id)} variant="secondary">{id}</Badge>
+                <Badge key={id} onClick={() => setKl(id)} variant="secondary">
+                  {id}
+                </Badge>
               ))}
             </div>
           )}
           {policies.length > 0 && (
             <div className="mt-3">
-                <Label>Existing policies (for this product)</Label>
+              <Label>Existing policies (for this product)</Label>
               <div className="mt-2 flex flex-col gap-2">
                 {policies.map((p) => (
                   <Button key={p.id} variant="secondary" onClick={() => setKl(p.id)}>
-                    {(p.name ?? p.id)} — {p.id}
+                    {p.name ?? p.id} — {p.id}
                   </Button>
                 ))}
               </div>
@@ -277,9 +277,13 @@ const KeygenProductWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
         <div className="col-span-1 md:col-span-2 flex items-center gap-3">
           <Switch checked={autoValidate} onCheckedChange={setAutoValidate} />
           <Text>Automatically validate before saving</Text>
-          <Button variant="secondary" onClick={handleValidate}>Validate only</Button>
+          <Button variant="secondary" onClick={handleValidate}>
+            Validate only
+          </Button>
           <div className="flex-1" />
-          <Button disabled={!canSave} onClick={handleSave}>Save</Button>
+          <Button disabled={!canSave} onClick={handleSave}>
+            Save
+          </Button>
         </div>
       </div>
 
@@ -288,21 +292,35 @@ const KeygenProductWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
         <Text className="text-ui-fg-subtle">Name can be generated automatically if desired.</Text>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div className="md:col-span-2">
-          <Checkbox checked={autoName} onCheckedChange={setAutoName} />
-          <Label className="ml-2">Generate name automatically</Label>
-          {autoName && <Text className="block mt-1">Preview: <strong>{generatedName}</strong></Text>}
+            <Checkbox checked={autoName} onCheckedChange={setAutoName} />
+            <Label className="ml-2">Generate name automatically</Label>
+            {autoName && (
+              <Text className="block mt-1">
+                Preview: <strong>{generatedName}</strong>
+              </Text>
+            )}
           </div>
           <div>
             <Label>Base name</Label>
-            <Input placeholder="Annual" value={baseName} onChange={(e) => setBaseName(e.target.value)} disabled={autoName} />
+            <Input
+              placeholder="Annual"
+              value={baseName}
+              onChange={(e) => setBaseName(e.target.value)}
+              disabled={autoName}
+            />
           </div>
           <div>
             <Label>Seats (maxMachines)</Label>
-            <Input type="number" min={1} value={seats} onChange={(e) => setSeats(parseInt(e.target.value || "1"))} />
+            <Input type="number" min={1} value={seats} onChange={(e) => setSeats(parseInt(e.target.value || '1'))} />
           </div>
           <div>
             <Label>Duration (days)</Label>
-            <Input type="number" min={0} value={durationDays} onChange={(e) => setDurationDays(parseInt(e.target.value || "0"))} />
+            <Input
+              type="number"
+              min={0}
+              value={durationDays}
+              onChange={(e) => setDurationDays(parseInt(e.target.value || '0'))}
+            />
             <Text className="text-ui-fg-subtle">0 = unlimited</Text>
           </div>
           <div className="flex items-center gap-2">
@@ -313,7 +331,7 @@ const KeygenProductWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
 
         {entitlements.length > 0 && (
           <div className="mt-3">
-              <Label>Attach entitlements</Label>
+            <Label>Attach entitlements</Label>
             <div className="mt-2 flex flex-wrap gap-2">
               {entitlements.map((e) => {
                 const checked = selectedEntitlements.includes(e.id)
@@ -322,7 +340,7 @@ const KeygenProductWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
                   <Badge
                     asChild
                     key={e.id}
-                    variant={checked ? "primary" : "secondary"}
+                    variant={checked ? 'primary' : 'secondary'}
                     onClick={() => toggleEntitlement(e.id)}
                   >
                     <button>{label}</button>
@@ -347,25 +365,46 @@ const KeygenProductWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
           </div>
           <div>
             <Label>Target product ID</Label>
-            <Input placeholder="prod_XXXX" value={cloneTargetProductId} onChange={(e) => setCloneTargetProductId(e.target.value)} />
+            <Input
+              placeholder="prod_XXXX"
+              value={cloneTargetProductId}
+              onChange={(e) => setCloneTargetProductId(e.target.value)}
+            />
           </div>
           <div className="md:col-span-2">
             <Text className="text-ui-fg-subtle">Optional overrides:</Text>
           </div>
           <div>
             <Label>Name</Label>
-            <Input placeholder="(leave empty for original)" value={cloneOverrideName} onChange={(e) => setCloneOverrideName(e.target.value)} />
+            <Input
+              placeholder="(leave empty for original)"
+              value={cloneOverrideName}
+              onChange={(e) => setCloneOverrideName(e.target.value)}
+            />
           </div>
           <div>
             <Label>Seats (maxMachines)</Label>
-            <Input type="number" placeholder="(leave empty)" value={cloneOverrideSeats ?? ""} onChange={(e) => setCloneOverrideSeats(e.target.value ? parseInt(e.target.value) : undefined)} />
+            <Input
+              type="number"
+              placeholder="(leave empty)"
+              value={cloneOverrideSeats ?? ''}
+              onChange={(e) => setCloneOverrideSeats(e.target.value ? parseInt(e.target.value) : undefined)}
+            />
           </div>
           <div>
             <Label>Duration (days)</Label>
-            <Input type="number" placeholder="(leave empty)" value={cloneOverrideDurationDays ?? ""} onChange={(e) => setCloneOverrideDurationDays(e.target.value ? parseInt(e.target.value) : undefined)} />
+            <Input
+              type="number"
+              placeholder="(leave empty)"
+              value={cloneOverrideDurationDays ?? ''}
+              onChange={(e) => setCloneOverrideDurationDays(e.target.value ? parseInt(e.target.value) : undefined)}
+            />
           </div>
           <div className="flex items-center gap-2">
-            <Checkbox checked={cloneOverrideFloating ?? false} onCheckedChange={(v) => setCloneOverrideFloating(v as boolean)} />
+            <Checkbox
+              checked={cloneOverrideFloating ?? false}
+              onCheckedChange={(v) => setCloneOverrideFloating(v as boolean)}
+            />
             <Label>Set floating (leave empty for original)</Label>
           </div>
         </div>
@@ -378,7 +417,7 @@ const KeygenProductWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
 }
 
 export const config = defineWidgetConfig({
-  zone: "product.details.after",
+  zone: 'product.details.after',
 })
 
 export default KeygenProductWidget

--- a/src/admin/widgets/keygen-variant.tsx
+++ b/src/admin/widgets/keygen-variant.tsx
@@ -1,25 +1,21 @@
+import { defineWidgetConfig } from '@medusajs/admin-sdk'
+import type { DetailWidgetProps, AdminProductVariant } from '@medusajs/framework/types'
+import { Container, Heading, Input, Button, Label, Text, Badge, Switch } from '@medusajs/ui'
+import { useEffect, useMemo, useState } from 'react'
+import { loadRecent, validateOnServer, ValidationResponse } from '../utils/keygen'
 
-import { defineWidgetConfig } from "@medusajs/admin-sdk"
-import type { DetailWidgetProps, AdminProductVariant } from "@medusajs/framework/types"
-import { Container, Heading, Input, Button, Label, Text, Badge, Switch } from "@medusajs/ui"
-import { useEffect, useMemo, useState } from "react"
-import { loadRecent, validateOnServer, ValidationResponse } from "../utils/keygen"
+const LS_RECENT_PRODUCTS = 'keygen_recent_products'
+const LS_RECENT_POLICIES = 'keygen_recent_policies'
 
-const LS_RECENT_PRODUCTS = "keygen_recent_products"
-const LS_RECENT_POLICIES = "keygen_recent_policies"
-
-async function patchVariantMetadata(
-  variantId: string,
-  meta: Record<string, unknown>
-) {
+async function patchVariantMetadata(variantId: string, meta: Record<string, unknown>) {
   const res = await fetch(`/admin/variants/${variantId}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "include",
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
     body: JSON.stringify({ metadata: meta }),
   })
   if (!res.ok) {
-    const t = await res.text().catch(() => "")
+    const t = await res.text().catch(() => '')
     throw new Error(`Update failed: ${res.status} ${t}`)
   }
   return await res.json()
@@ -27,14 +23,16 @@ async function patchVariantMetadata(
 
 const KeygenVariantWidget = ({ data }: DetailWidgetProps<AdminProductVariant>) => {
   const currentMeta = data?.metadata ?? {}
-  const [kp, setKp] = useState<string>(String(currentMeta["keygen_product"] ?? ""))
-  const [kl, setKl] = useState<string>(String(currentMeta["keygen_policy"] ?? ""))
-  const [vp, setVp] = useState<{ok:boolean;message?:string;name?:string}|null>(null)
-  const [vl, setVl] = useState<{ok:boolean;message?:string;name?:string}|null>(null)
+  const [kp, setKp] = useState<string>(String(currentMeta['keygen_product'] ?? ''))
+  const [kl, setKl] = useState<string>(String(currentMeta['keygen_policy'] ?? ''))
+  const [vp, setVp] = useState<{ ok: boolean; message?: string; name?: string } | null>(null)
+  const [vl, setVl] = useState<{ ok: boolean; message?: string; name?: string } | null>(null)
   const [autoValidate, setAutoValidate] = useState(true)
 
-  const canSave = useMemo(() => kp !== String(currentMeta["keygen_product"] ?? "") ||
-                                  kl !== String(currentMeta["keygen_policy"] ?? ""), [kp, kl, currentMeta])
+  const canSave = useMemo(
+    () => kp !== String(currentMeta['keygen_product'] ?? '') || kl !== String(currentMeta['keygen_policy'] ?? ''),
+    [kp, kl, currentMeta],
+  )
 
   const [recentProducts, setRecentProducts] = useState<string[]>([])
   const [recentPolicies, setRecentPolicies] = useState<string[]>([])
@@ -44,24 +42,16 @@ const KeygenVariantWidget = ({ data }: DetailWidgetProps<AdminProductVariant>) =
   }, [])
 
   async function handleValidate() {
-    const resP: ValidationResponse = kp
-      ? await validateOnServer("product", kp)
-      : { ok: true }
-    const resL: ValidationResponse = kl
-      ? await validateOnServer("policy", kl)
-      : { ok: true }
+    const resP: ValidationResponse = kp ? await validateOnServer('product', kp) : { ok: true }
+    const resL: ValidationResponse = kl ? await validateOnServer('policy', kl) : { ok: true }
     setVp(resP.ok ? { ok: true, name: resP.data?.name } : { ok: false, message: resP.message })
     setVl(resL.ok ? { ok: true, name: resL.data?.name } : { ok: false, message: resL.message })
   }
 
   async function handleSave() {
     if (autoValidate) {
-      const resP: ValidationResponse = kp
-        ? await validateOnServer("product", kp)
-        : { ok: true }
-      const resL: ValidationResponse = kl
-        ? await validateOnServer("policy", kl)
-        : { ok: true }
+      const resP: ValidationResponse = kp ? await validateOnServer('product', kp) : { ok: true }
+      const resL: ValidationResponse = kl ? await validateOnServer('policy', kl) : { ok: true }
       if (!resP.ok || !resL.ok) {
         setVp(resP.ok ? { ok: true, name: resP.data?.name } : { ok: false, message: resP.message })
         setVl(resL.ok ? { ok: true, name: resL.data?.name } : { ok: false, message: resL.message })
@@ -89,12 +79,14 @@ const KeygenVariantWidget = ({ data }: DetailWidgetProps<AdminProductVariant>) =
         <div>
           <Label>Keygen Product ID (keygen_product)</Label>
           <Input placeholder="prod_XXXX" value={kp} onChange={(e) => setKp(e.target.value)} />
-          {vp?.ok && kp && <Text className="mt-1">✅ Found: {vp.name ?? "OK"}</Text>}
+          {vp?.ok && kp && <Text className="mt-1">✅ Found: {vp.name ?? 'OK'}</Text>}
           {vp?.ok === false && <Text className="mt-1 text-ui-fg-error">❌ {vp.message}</Text>}
           {recentProducts.length > 0 && (
             <div className="mt-2 flex flex-wrap gap-2">
               {recentProducts.map((id) => (
-                <Badge key={id} onClick={() => setKp(id)} variant="secondary">{id}</Badge>
+                <Badge key={id} onClick={() => setKp(id)} variant="secondary">
+                  {id}
+                </Badge>
               ))}
             </div>
           )}
@@ -103,12 +95,14 @@ const KeygenVariantWidget = ({ data }: DetailWidgetProps<AdminProductVariant>) =
         <div>
           <Label>Keygen Policy ID (keygen_policy)</Label>
           <Input placeholder="pol_XXXX" value={kl} onChange={(e) => setKl(e.target.value)} />
-          {vl?.ok && kl && <Text className="mt-1">✅ Found: {vl.name ?? "OK"}</Text>}
+          {vl?.ok && kl && <Text className="mt-1">✅ Found: {vl.name ?? 'OK'}</Text>}
           {vl?.ok === false && <Text className="mt-1 text-ui-fg-error">❌ {vl.message}</Text>}
           {recentPolicies.length > 0 && (
             <div className="mt-2 flex flex-wrap gap-2">
               {recentPolicies.map((id) => (
-                <Badge key={id} onClick={() => setKl(id)} variant="secondary">{id}</Badge>
+                <Badge key={id} onClick={() => setKl(id)} variant="secondary">
+                  {id}
+                </Badge>
               ))}
             </div>
           )}
@@ -117,9 +111,13 @@ const KeygenVariantWidget = ({ data }: DetailWidgetProps<AdminProductVariant>) =
         <div className="col-span-1 md:col-span-2 flex items-center gap-3">
           <Switch checked={autoValidate} onCheckedChange={setAutoValidate} />
           <Text>Automatically validate before saving</Text>
-          <Button variant="secondary" onClick={handleValidate}>Validate only</Button>
+          <Button variant="secondary" onClick={handleValidate}>
+            Validate only
+          </Button>
           <div className="flex-1" />
-          <Button disabled={!canSave} onClick={handleSave}>Save</Button>
+          <Button disabled={!canSave} onClick={handleSave}>
+            Save
+          </Button>
         </div>
       </div>
     </Container>
@@ -127,7 +125,7 @@ const KeygenVariantWidget = ({ data }: DetailWidgetProps<AdminProductVariant>) =
 }
 
 export const config = defineWidgetConfig({
-  zone: "product.variant.details.after",
+  zone: 'product.variant.details.after',
 })
 
 export default KeygenVariantWidget

--- a/src/api/admin/keygen/customers/[customer_id]/licenses/route.ts
+++ b/src/api/admin/keygen/customers/[customer_id]/licenses/route.ts
@@ -1,47 +1,43 @@
-import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import KeygenService from "../../../../../../modules/keygen/service"
+import type { MedusaRequest, MedusaResponse } from '@medusajs/framework/http'
+import KeygenService from '../../../../../../modules/keygen/service'
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const { customer_id } = req.params as { customer_id: string }
-  const query = req.scope.resolve("query") as {
+  const query = req.scope.resolve('query') as {
     graph<T>(cfg: Record<string, unknown>): Promise<{
       data: T[] | null
       metadata?: { count?: number }
     }>
   }
-  const keygen = req.scope.resolve<KeygenService>("keygenService")
+  const keygen = req.scope.resolve<KeygenService>('keygenService')
 
-  const { limit: limitParam, offset: offsetParam, q, order } = (req.query ?? {}) as {
+  const {
+    limit: limitParam,
+    offset: offsetParam,
+    q,
+    order,
+  } = (req.query ?? {}) as {
     limit?: string
     offset?: string
     q?: string
     order?: string
   }
 
-  const shouldPaginate =
-    typeof limitParam !== "undefined" || typeof offsetParam !== "undefined"
+  const shouldPaginate = typeof limitParam !== 'undefined' || typeof offsetParam !== 'undefined'
 
-  const take = shouldPaginate ? parseInt(limitParam ?? "20", 10) : undefined
-  const skip = shouldPaginate ? parseInt(offsetParam ?? "0", 10) : undefined
+  const take = shouldPaginate ? parseInt(limitParam ?? '20', 10) : undefined
+  const skip = shouldPaginate ? parseInt(offsetParam ?? '0', 10) : undefined
 
-  let orderBy: Record<string, "asc" | "desc"> | undefined
+  let orderBy: Record<string, 'asc' | 'desc'> | undefined
   if (order) {
-    const [field, direction] = order.split(":")
-    orderBy = { [field]: (direction as "asc" | "desc") ?? "asc" }
+    const [field, direction] = order.split(':')
+    orderBy = { [field]: (direction as 'asc' | 'desc') ?? 'asc' }
   }
 
   const { data, metadata } = await query.graph<LicenseRow>({
-    entity: "keygen_license",
+    entity: 'keygen_license',
     filters: { customer_id, ...(q ? { q } : {}) },
-    fields: [
-      "id",
-      "license_key",
-      "keygen_license_id",
-      "status",
-      "keygen_policy_id",
-      "keygen_product_id",
-      "created_at",
-    ],
+    fields: ['id', 'license_key', 'keygen_license_id', 'status', 'keygen_policy_id', 'keygen_product_id', 'created_at'],
     ...(shouldPaginate ? { pagination: { take, skip } } : {}),
     ...(orderBy ? { orderBy } : {}),
   })
@@ -71,7 +67,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
           max_machines: det.maxMachines,
           machines: det.machines,
         }
-      } catch (e) {
+      } catch {
         return {
           id: l.keygen_license_id,
           key: l.license_key,
@@ -82,7 +78,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
           machines: [],
         }
       }
-    })
+    }),
   )
 
   if (shouldPaginate) {

--- a/src/api/admin/keygen/entitlements/route.ts
+++ b/src/api/admin/keygen/entitlements/route.ts
@@ -1,26 +1,25 @@
-
-import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { env } from "../../../../config/env"
+import type { MedusaRequest, MedusaResponse } from '@medusajs/framework/http'
+import { env } from '../../../../config/env'
 
 export const GET = async (_req: MedusaRequest, res: MedusaResponse) => {
   const account = env.KEYGEN_ACCOUNT
   const token = env.KEYGEN_TOKEN
   const version = env.KEYGEN_VERSION
   if (!account || !token) {
-    return res.status(500).json({ message: "KEYGEN_ACCOUNT/TOKEN missing" })
+    return res.status(500).json({ message: 'KEYGEN_ACCOUNT/TOKEN missing' })
   }
 
   const host = env.KEYGEN_HOST
   const r = await fetch(`${host}/v1/accounts/${account}/entitlements`, {
     headers: {
       Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-      "Keygen-Version": version,
+      Accept: 'application/json',
+      'Keygen-Version': version,
     },
   })
 
   if (!r.ok) {
-    const text = await r.text().catch(() => "")
+    const text = await r.text().catch(() => '')
     return res.status(r.status).json({ message: text || r.statusText })
   }
 

--- a/src/api/admin/keygen/licenses/[order_id]/route.ts
+++ b/src/api/admin/keygen/licenses/[order_id]/route.ts
@@ -1,25 +1,24 @@
-
-import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import KeygenService from "../../../../../modules/keygen/service"
+import type { MedusaRequest, MedusaResponse } from '@medusajs/framework/http'
+import KeygenService from '../../../../../modules/keygen/service'
 
 // Lists all Keygen licenses for a given order.
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const { order_id } = req.params as { order_id: string }
-  const query = req.scope.resolve("query")
+  const query = req.scope.resolve('query')
 
   const { data } = await query.graph({
-    entity: "keygen_license",
+    entity: 'keygen_license',
     filters: { order_id },
     fields: [
-      "id",
-      "order_id",
-      "order_item_id",
-      "license_key",
-      "keygen_license_id",
-      "status",
-      "keygen_policy_id",
-      "keygen_product_id",
-      "created_at",
+      'id',
+      'order_id',
+      'order_item_id',
+      'license_key',
+      'keygen_license_id',
+      'status',
+      'keygen_policy_id',
+      'keygen_product_id',
+      'created_at',
     ],
   })
 
@@ -29,7 +28,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
 // Manually issues a new license for the provided order.
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const { order_id } = req.params as { order_id: string }
-  const keygen = req.scope.resolve<KeygenService>("keygenService")
+  const keygen = req.scope.resolve<KeygenService>('keygenService')
   const { policyId, productId, orderItemId } = (req.body ?? {}) as {
     policyId?: string
     productId?: string
@@ -37,7 +36,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   }
 
   if (!policyId && !productId) {
-    return res.status(400).json({ message: "policyId or productId required" })
+    return res.status(400).json({ message: 'policyId or productId required' })
   }
 
   const { record } = await keygen.createLicense({

--- a/src/api/admin/keygen/machines/[machine_id]/route.ts
+++ b/src/api/admin/keygen/machines/[machine_id]/route.ts
@@ -1,15 +1,15 @@
-import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import KeygenService from "../../../../../modules/keygen/service"
+import type { MedusaRequest, MedusaResponse } from '@medusajs/framework/http'
+import KeygenService from '../../../../../modules/keygen/service'
 
 export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
   const { machine_id } = req.params as { machine_id: string }
-  const keygen = req.scope.resolve<KeygenService>("keygenService")
+  const keygen = req.scope.resolve<KeygenService>('keygenService')
 
   try {
     await keygen.deleteMachine(machine_id)
     return res.status(204).json({})
   } catch (e: unknown) {
-    const message = e instanceof Error ? e.message : "Failed to delete machine"
+    const message = e instanceof Error ? e.message : 'Failed to delete machine'
     return res.status(500).json({ message })
   }
 }

--- a/src/api/admin/keygen/policies/clone/route.ts
+++ b/src/api/admin/keygen/policies/clone/route.ts
@@ -1,12 +1,11 @@
-
-import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { env } from "../../../../../config/env"
+import type { MedusaRequest, MedusaResponse } from '@medusajs/framework/http'
+import { env } from '../../../../../config/env'
 
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const account = env.KEYGEN_ACCOUNT
   const token = env.KEYGEN_TOKEN
   if (!account || !token) {
-    return res.status(500).json({ message: "KEYGEN_ACCOUNT/TOKEN missing" })
+    return res.status(500).json({ message: 'KEYGEN_ACCOUNT/TOKEN missing' })
   }
   const version = env.KEYGEN_VERSION
 
@@ -23,16 +22,16 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   }
 
   if (!sourcePolicyId || !targetProductId) {
-    return res.status(400).json({ message: "sourcePolicyId and targetProductId are required fields" })
+    return res.status(400).json({ message: 'sourcePolicyId and targetProductId are required fields' })
   }
 
   // 1) Read source policy
   const host = env.KEYGEN_HOST
   const src = await fetch(`${host}/v1/accounts/${account}/policies/${sourcePolicyId}`, {
-    headers: { Authorization: `Bearer ${token}`, Accept: "application/json", "Keygen-Version": version }
+    headers: { Authorization: `Bearer ${token}`, Accept: 'application/json', 'Keygen-Version': version },
   })
   if (!src.ok) {
-    const text = await src.text().catch(() => "")
+    const text = await src.text().catch(() => '')
     return res.status(src.status).json({ message: text || src.statusText })
   }
   const srcJson = (await src.json()) as {
@@ -49,33 +48,45 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
 
   const payload: Record<string, unknown> = {
     data: {
-      type: "policies",
+      type: 'policies',
       attributes: {
         name: overrides?.name ?? attrs.name,
-        ...(overrides?.maxMachines != null ? { maxMachines: overrides.maxMachines } : (attrs.maxMachines != null ? { maxMachines: attrs.maxMachines } : {})),
-        ...(overrides?.floating != null ? { floating: overrides.floating } : (attrs.floating != null ? { floating: attrs.floating } : {})),
-        ...(overrides?.duration != null ? { duration: overrides.duration } : (attrs.duration != null ? { duration: attrs.duration } : {})),
+        ...(overrides?.maxMachines != null
+          ? { maxMachines: overrides.maxMachines }
+          : attrs.maxMachines != null
+            ? { maxMachines: attrs.maxMachines }
+            : {}),
+        ...(overrides?.floating != null
+          ? { floating: overrides.floating }
+          : attrs.floating != null
+            ? { floating: attrs.floating }
+            : {}),
+        ...(overrides?.duration != null
+          ? { duration: overrides.duration }
+          : attrs.duration != null
+            ? { duration: attrs.duration }
+            : {}),
       },
       relationships: {
-        product: { data: { type: "products", id: targetProductId } }
-      }
-    }
+        product: { data: { type: 'products', id: targetProductId } },
+      },
+    },
   }
 
   // 2) Create new policy on target product
   const r = await fetch(`${host}/v1/accounts/${account}/policies`, {
-    method: "POST",
+    method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      "Keygen-Version": version,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'Keygen-Version': version,
     },
     body: JSON.stringify(payload),
   })
 
   if (!r.ok) {
-    const text = await r.text().catch(() => "")
+    const text = await r.text().catch(() => '')
     return res.status(r.status).json({ message: text || r.statusText })
   }
 
@@ -86,28 +97,26 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   let entitlementsToAttach: string[] | undefined = overrides?.entitlementIds
   if (!entitlementsToAttach) {
     const ents = await fetch(`${host}/v1/accounts/${account}/policies/${sourcePolicyId}/entitlements`, {
-      headers: { Authorization: `Bearer ${token}`, Accept: "application/json", "Keygen-Version": version }
+      headers: { Authorization: `Bearer ${token}`, Accept: 'application/json', 'Keygen-Version': version },
     })
     if (ents.ok) {
       const entsJson = (await ents.json()) as { data?: { id?: string }[] }
-      entitlementsToAttach = (entsJson.data || [])
-        .map((e) => e?.id)
-        .filter((id): id is string => Boolean(id))
+      entitlementsToAttach = (entsJson.data || []).map((e) => e?.id).filter((id): id is string => Boolean(id))
     }
   }
 
   if (newId && entitlementsToAttach && entitlementsToAttach.length > 0) {
     await fetch(`${host}/v1/accounts/${account}/policies/${newId}/relationships/entitlements`, {
-      method: "POST",
+      method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
-        Accept: "application/json",
-        "Content-Type": "application/json",
-        "Keygen-Version": version,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'Keygen-Version': version,
       },
       body: JSON.stringify({
-        data: entitlementsToAttach.map((eid) => ({ type: "entitlements", id: eid }))
-      })
+        data: entitlementsToAttach.map((eid) => ({ type: 'entitlements', id: eid })),
+      }),
     })
   }
 

--- a/src/api/admin/keygen/policies/route.ts
+++ b/src/api/admin/keygen/policies/route.ts
@@ -1,35 +1,34 @@
-
-import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { env } from "../../../../config/env"
+import type { MedusaRequest, MedusaResponse } from '@medusajs/framework/http'
+import { env } from '../../../../config/env'
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const account = env.KEYGEN_ACCOUNT
   const token = env.KEYGEN_TOKEN
   if (!account || !token) {
-    return res.status(500).json({ message: "KEYGEN_ACCOUNT/TOKEN missing" })
+    return res.status(500).json({ message: 'KEYGEN_ACCOUNT/TOKEN missing' })
   }
   const version = env.KEYGEN_VERSION
-  const productId = (req.query?.productId as string) || ""
+  const productId = (req.query?.productId as string) || ''
 
   const host = env.KEYGEN_HOST
   let url = `${host}/v1/accounts/${account}/policies`
   if (productId) {
     const u = new URL(url)
     // filter by product
-    u.searchParams.set("filter[product]", productId)
+    u.searchParams.set('filter[product]', productId)
     url = u.toString()
   }
 
   const r = await fetch(url, {
     headers: {
       Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-      "Keygen-Version": version,
+      Accept: 'application/json',
+      'Keygen-Version': version,
     },
   })
 
   if (!r.ok) {
-    const text = await r.text().catch(() => "")
+    const text = await r.text().catch(() => '')
     return res.status(r.status).json({ message: text || r.statusText })
   }
 
@@ -48,7 +47,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const account = env.KEYGEN_ACCOUNT
   const token = env.KEYGEN_TOKEN
   if (!account || !token) {
-    return res.status(500).json({ message: "KEYGEN_ACCOUNT/TOKEN missing" })
+    return res.status(500).json({ message: 'KEYGEN_ACCOUNT/TOKEN missing' })
   }
   const version = env.KEYGEN_VERSION
 
@@ -62,38 +61,38 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   }
 
   if (!productId || !name) {
-    return res.status(400).json({ message: "productId and name are required fields" })
+    return res.status(400).json({ message: 'productId and name are required fields' })
   }
 
   const payload: Record<string, unknown> = {
     data: {
-      type: "policies",
+      type: 'policies',
       attributes: {
         name,
-        ...(typeof maxMachines === "number" ? { maxMachines } : {}),
-        ...(typeof floating === "boolean" ? { floating } : {}),
-        ...(typeof duration === "number" ? { duration } : {}),
+        ...(typeof maxMachines === 'number' ? { maxMachines } : {}),
+        ...(typeof floating === 'boolean' ? { floating } : {}),
+        ...(typeof duration === 'number' ? { duration } : {}),
       },
       relationships: {
-        product: { data: { type: "products", id: productId } }
-      }
-    }
+        product: { data: { type: 'products', id: productId } },
+      },
+    },
   }
 
   const host = env.KEYGEN_HOST
   const r = await fetch(`${host}/v1/accounts/${account}/policies`, {
-    method: "POST",
+    method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      "Keygen-Version": version,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'Keygen-Version': version,
     },
     body: JSON.stringify(payload),
   })
 
   if (!r.ok) {
-    const text = await r.text().catch(() => "")
+    const text = await r.text().catch(() => '')
     return res.status(r.status).json({ message: text || r.statusText })
   }
 
@@ -106,16 +105,16 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   // attach entitlements if provided
   if (id && Array.isArray(entitlementIds) && entitlementIds.length > 0) {
     await fetch(`${host}/v1/accounts/${account}/policies/${id}/relationships/entitlements`, {
-      method: "POST",
+      method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
-        Accept: "application/json",
-        "Content-Type": "application/json",
-        "Keygen-Version": version,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'Keygen-Version': version,
       },
       body: JSON.stringify({
-        data: entitlementIds.map((eid) => ({ type: "entitlements", id: eid }))
-      })
+        data: entitlementIds.map((eid) => ({ type: 'entitlements', id: eid })),
+      }),
     })
   }
 

--- a/src/api/admin/keygen/validate/route.ts
+++ b/src/api/admin/keygen/validate/route.ts
@@ -1,49 +1,44 @@
-
-import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { env } from "../../../../config/env"
+import type { MedusaRequest, MedusaResponse } from '@medusajs/framework/http'
+import { env } from '../../../../config/env'
 
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
-  const { type, id } = (req.body ?? {}) as { type: "product" | "policy"; id: string }
+  const { type, id } = (req.body ?? {}) as { type: 'product' | 'policy'; id: string }
   const account = env.KEYGEN_ACCOUNT
   const token = env.KEYGEN_TOKEN
   const version = env.KEYGEN_VERSION
 
   if (!account || !token) {
-    return res.status(500).json({ message: "KEYGEN_ACCOUNT/TOKEN missing" })
+    return res.status(500).json({ message: 'KEYGEN_ACCOUNT/TOKEN missing' })
   }
-  if (!id || (type !== "product" && type !== "policy")) {
-    return res.status(400).json({ message: "Invalid request" })
+  if (!id || (type !== 'product' && type !== 'policy')) {
+    return res.status(400).json({ message: 'Invalid request' })
   }
 
   const host = env.KEYGEN_HOST
   const url =
-    type === "product"
+    type === 'product'
       ? `${host}/v1/accounts/${account}/products/${id}`
       : `${host}/v1/accounts/${account}/policies/${id}`
 
   const r = await fetch(url, {
     headers: {
       Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-      "Keygen-Version": version,
+      Accept: 'application/json',
+      'Keygen-Version': version,
     },
   })
 
   if (!r.ok) {
-    const text = await r.text().catch(() => "")
-    console.error(
-      `[keygen] validation request failed: ${r.status} ${text || r.statusText}`
-    )
-    return res.status(r.status).json({ message: "Validation failed" })
+    const text = await r.text().catch(() => '')
+    console.error(`[keygen] validation request failed: ${r.status} ${text || r.statusText}`)
+    return res.status(r.status).json({ message: 'Validation failed' })
   }
 
   const json = (await r.json()) as {
     data?: { id?: string; attributes?: { name?: string; code?: string } }
   }
   const name =
-    json?.data?.attributes?.name ||
-    json?.data?.id ||
-    (type === "policy" ? json?.data?.attributes?.code : undefined)
+    json?.data?.attributes?.name || json?.data?.id || (type === 'policy' ? json?.data?.attributes?.code : undefined)
 
   return res.json({ id, type, name })
 }

--- a/src/api/store/licensing/activate/route.ts
+++ b/src/api/store/licensing/activate/route.ts
@@ -1,6 +1,6 @@
-import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { SeatsExhaustedError } from "../../../../modules/keygen/service"
-import KeygenService from "../../../../modules/keygen/service"
+import type { MedusaRequest, MedusaResponse } from '@medusajs/framework/http'
+import { SeatsExhaustedError } from '../../../../modules/keygen/service'
+import KeygenService from '../../../../modules/keygen/service'
 
 type AuthenticatedRequest = MedusaRequest & {
   user?: { id?: string; customer_id?: string }
@@ -13,7 +13,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const customerId = user?.customer_id || user?.id
 
   if (!customerId) {
-    return res.status(401).json({ message: "Unauthorized" })
+    return res.status(401).json({ message: 'Unauthorized' })
   }
 
   const { productId, device } = (req.body ?? {}) as {
@@ -27,25 +27,23 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   }
 
   if (!productId || !device?.fingerprint) {
-    return res
-      .status(400)
-      .json({ message: "productId and device.fingerprint are required" })
+    return res.status(400).json({ message: 'productId and device.fingerprint are required' })
   }
 
-  const query = req.scope.resolve("query")
+  const query = req.scope.resolve('query')
   const { data } = await query.graph({
-    entity: "keygen_license",
+    entity: 'keygen_license',
     filters: { customer_id: customerId, keygen_product_id: productId },
-    fields: ["keygen_license_id"],
+    fields: ['keygen_license_id'],
     pagination: { take: 1 },
   })
 
   const license = data?.[0]
   if (!license?.keygen_license_id) {
-    return res.status(404).json({ message: "License not found" })
+    return res.status(404).json({ message: 'License not found' })
   }
 
-  const keygen = req.scope.resolve<KeygenService>("keygenService")
+  const keygen = req.scope.resolve<KeygenService>('keygenService')
 
   try {
     const result = await keygen.activateMachine({
@@ -56,7 +54,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     })
 
     return res.json({
-      status: "ACTIVATED",
+      status: 'ACTIVATED',
       licenseId: license.keygen_license_id,
       machineId: result.machineId,
       seats: result.seats,
@@ -64,15 +62,15 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   } catch (e: unknown) {
     if (e instanceof SeatsExhaustedError) {
       return res.status(409).json({
-        status: "DENIED",
-        code: "SEATS_EXHAUSTED",
+        status: 'DENIED',
+        code: 'SEATS_EXHAUSTED',
         message:
-          "Keine freien Geräteplätze auf dieser Lizenz. Bitte entfernen Sie ein Gerät im Kundenkonto oder kontaktieren Sie den Support.",
+          'Keine freien Geräteplätze auf dieser Lizenz. Bitte entfernen Sie ein Gerät im Kundenkonto oder kontaktieren Sie den Support.',
         seats: e.seats,
       })
     }
 
-    const message = e instanceof Error ? e.message : "Activation failed"
+    const message = e instanceof Error ? e.message : 'Activation failed'
     return res.status(500).json({ message })
   }
 }

--- a/src/api/store/licensing/devices/[machine_id]/route.ts
+++ b/src/api/store/licensing/devices/[machine_id]/route.ts
@@ -1,15 +1,15 @@
-import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import KeygenService from "../../../../../modules/keygen/service"
+import type { MedusaRequest, MedusaResponse } from '@medusajs/framework/http'
+import KeygenService from '../../../../../modules/keygen/service'
 
 export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
   const { machine_id } = req.params as { machine_id: string }
-  const keygen = req.scope.resolve<KeygenService>("keygenService")
+  const keygen = req.scope.resolve<KeygenService>('keygenService')
 
   try {
     await keygen.deleteMachine(machine_id)
     return res.status(204).json({})
   } catch (e: unknown) {
-    const message = e instanceof Error ? e.message : "Failed to delete machine"
+    const message = e instanceof Error ? e.message : 'Failed to delete machine'
     return res.status(500).json({ message })
   }
 }

--- a/src/api/store/me/licenses/[license_id]/download/route.ts
+++ b/src/api/store/me/licenses/[license_id]/download/route.ts
@@ -1,7 +1,5 @@
-import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import KeygenService, {
-  DownloadLink,
-} from "../../../../../../modules/keygen/service"
+import type { MedusaRequest, MedusaResponse } from '@medusajs/framework/http'
+import KeygenService, { DownloadLink } from '../../../../../../modules/keygen/service'
 
 type AuthUser = { id?: string; customer_id?: string }
 interface DownloadBody {
@@ -11,18 +9,15 @@ interface DownloadBody {
 
 export const POST = async (
   req: MedusaRequest,
-  res: MedusaResponse<
-    { link: DownloadLink; licenseId: string; assetId: string } | { message: string }
-  >
+  res: MedusaResponse<{ link: DownloadLink; licenseId: string; assetId: string } | { message: string }>,
 ) => {
   const { user, auth } = req as unknown as {
     user?: AuthUser
     auth?: AuthUser
   }
-  const customerId =
-    user?.customer_id ?? user?.id ?? auth?.customer_id ?? auth?.id
+  const customerId = user?.customer_id ?? user?.id ?? auth?.customer_id ?? auth?.id
   if (!customerId) {
-    return res.status(401).json({ message: "Unauthorized" })
+    return res.status(401).json({ message: 'Unauthorized' })
   }
 
   const licenseId = req.params.license_id
@@ -30,25 +25,25 @@ export const POST = async (
   const { assetId, filename } = body || {}
 
   if (!assetId) {
-    return res.status(400).json({ message: "assetId is required" })
+    return res.status(400).json({ message: 'assetId is required' })
   }
 
-  const query = req.scope.resolve("query") as {
+  const query = req.scope.resolve('query') as {
     graph<T>(cfg: Record<string, unknown>): Promise<{ data: T[] | null }>
   }
   const { data } = await query.graph<{ keygen_license_id: string }>({
-    entity: "keygen_license",
+    entity: 'keygen_license',
     filters: { customer_id: customerId, keygen_license_id: licenseId },
-    fields: ["keygen_license_id"],
+    fields: ['keygen_license_id'],
     pagination: { take: 1 },
   })
 
   const license = data?.[0]
   if (!license) {
-    return res.status(404).json({ message: "License not found" })
+    return res.status(404).json({ message: 'License not found' })
   }
 
-  const keygen = req.scope.resolve<KeygenService>("keygenService")
+  const keygen = req.scope.resolve<KeygenService>('keygenService')
   try {
     const link = await keygen.createDownloadLink({
       licenseId: licenseId,
@@ -59,8 +54,6 @@ export const POST = async (
     return res.status(201).json({ link, licenseId, assetId })
   } catch (e) {
     const msg = e instanceof Error ? e.message : undefined
-    return res
-      .status(500)
-      .json({ message: msg || "Could not create download link" })
+    return res.status(500).json({ message: msg || 'Could not create download link' })
   }
 }

--- a/src/api/store/me/licenses/route.ts
+++ b/src/api/store/me/licenses/route.ts
@@ -1,4 +1,4 @@
-import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { MedusaRequest, MedusaResponse } from '@medusajs/framework/http'
 
 type AuthUser = { id?: string; customer_id?: string }
 type LicenseRow = {
@@ -15,13 +15,13 @@ type License = {
 }
 
 const maskKey = (key: string | null) => {
-  if (!key) return ""
-  const parts = key.split("-")
+  if (!key) return ''
+  const parts = key.split('-')
   if (parts.length <= 1) {
-    return key.length > 4 ? key.replace(/.(?=.{4})/g, "*") : key
+    return key.length > 4 ? key.replace(/.(?=.{4})/g, '*') : key
   }
   const last = parts.pop()!
-  return [...parts.map(() => "****"), last].join("-")
+  return [...parts.map(() => '****'), last].join('-')
 }
 
 export const GET = async (
@@ -30,20 +30,19 @@ export const GET = async (
     | { licenses: License[] }
     | { licenses: License[]; count: number; limit: number; offset: number }
     | { message: string }
-  >
+  >,
 ) => {
   const { user, auth } = req as unknown as {
     user?: AuthUser
     auth?: AuthUser
   }
-  const customerId =
-    user?.customer_id ?? user?.id ?? auth?.customer_id ?? auth?.id
+  const customerId = user?.customer_id ?? user?.id ?? auth?.customer_id ?? auth?.id
 
   if (!customerId) {
-    return res.status(401).json({ message: "Unauthorized" })
+    return res.status(401).json({ message: 'Unauthorized' })
   }
 
-  const query = req.scope.resolve("query") as {
+  const query = req.scope.resolve('query') as {
     graph<T>(cfg: Record<string, unknown>): Promise<{
       data: T[] | null
       metadata?: { count?: number }
@@ -68,16 +67,15 @@ export const GET = async (
     status?: string
   }
 
-  const shouldPaginate =
-    typeof limitParam !== "undefined" || typeof offsetParam !== "undefined"
+  const shouldPaginate = typeof limitParam !== 'undefined' || typeof offsetParam !== 'undefined'
 
-  const take = shouldPaginate ? parseInt(limitParam ?? "20", 10) : undefined
-  const skip = shouldPaginate ? parseInt(offsetParam ?? "0", 10) : undefined
+  const take = shouldPaginate ? parseInt(limitParam ?? '20', 10) : undefined
+  const skip = shouldPaginate ? parseInt(offsetParam ?? '0', 10) : undefined
 
-  let orderBy: Record<string, "asc" | "desc"> = { created_at: "desc" }
+  let orderBy: Record<string, 'asc' | 'desc'> = { created_at: 'desc' }
   if (order) {
-    const [field, direction] = order.split(":")
-    orderBy = { [field]: (direction as "asc" | "desc") ?? "asc" }
+    const [field, direction] = order.split(':')
+    orderBy = { [field]: (direction as 'asc' | 'desc') ?? 'asc' }
   }
 
   const filters: Record<string, unknown> = { customer_id: customerId }
@@ -87,14 +85,9 @@ export const GET = async (
   if (status) filters.status = status
 
   const cfg: Record<string, unknown> = {
-    entity: "keygen_license",
+    entity: 'keygen_license',
     filters,
-    fields: [
-      "keygen_license_id",
-      "license_key",
-      "status",
-      "keygen_product_id",
-    ],
+    fields: ['keygen_license_id', 'license_key', 'status', 'keygen_product_id'],
     ...(shouldPaginate ? { pagination: { take, skip } } : {}),
     ...(orderBy ? { orderBy } : {}),
   }
@@ -105,9 +98,7 @@ export const GET = async (
     id: l.keygen_license_id,
     key: maskKey(l.license_key),
     status: l.status,
-    ...(l.keygen_product_id
-      ? { product: { id: l.keygen_product_id } }
-      : {}),
+    ...(l.keygen_product_id ? { product: { id: l.keygen_product_id } } : {}),
   }))
 
   if (shouldPaginate) {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,10 +1,10 @@
-import { z } from "zod"
+import { z } from 'zod'
 
 const envSchema = z.object({
   KEYGEN_ACCOUNT: z.string().min(1),
   KEYGEN_TOKEN: z.string().min(1),
-  KEYGEN_HOST: z.string().url().default("https://api.keygen.sh"),
-  KEYGEN_VERSION: z.string().default("1.8"),
+  KEYGEN_HOST: z.string().url().default('https://api.keygen.sh'),
+  KEYGEN_VERSION: z.string().default('1.8'),
 })
 
 export const env = envSchema.parse(process.env)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,12 @@
+import type { LoaderOptions } from '@medusajs/framework/types'
+import KeygenService from './modules/keygen/service'
+import orderPlacedSubscriber from './subscribers/order-placed'
+import orderCanceledSubscriber from './subscribers/order-canceled'
+import orderRefundedSubscriber from './subscribers/order-refunded'
 
-import type { LoaderOptions } from "@medusajs/framework/types"
-import KeygenService from "./modules/keygen/service"
-import orderPlacedSubscriber from "./subscribers/order-placed"
-import orderCanceledSubscriber from "./subscribers/order-canceled"
-import orderRefundedSubscriber from "./subscribers/order-refunded"
-
-export default async function keygenPlugin(_: LoaderOptions) {
+export default async function keygenPlugin(_options: LoaderOptions) {
   return {
     services: [KeygenService],
-    subscribers: [
-      orderPlacedSubscriber,
-      orderCanceledSubscriber,
-      orderRefundedSubscriber,
-    ],
+    subscribers: [orderPlacedSubscriber, orderCanceledSubscriber, orderRefundedSubscriber],
   }
 }

--- a/src/middleware/verify-keygen-webhook.ts
+++ b/src/middleware/verify-keygen-webhook.ts
@@ -1,42 +1,38 @@
-import crypto from "crypto"
-import type { Request, Response, NextFunction } from "express"
+import crypto from 'crypto'
+import type { Request, Response, NextFunction } from 'express'
 
 type RawRequest = Request & { rawBody?: Buffer | string }
 
-export default function verifyKeygenWebhook(
-  req: RawRequest,
-  res: Response,
-  next: NextFunction
-) {
+export default function verifyKeygenWebhook(req: RawRequest, res: Response, next: NextFunction) {
   const secret = process.env.KEYGEN_WEBHOOK_SECRET
-  const signatureHeader = req.headers["x-signature"]
+  const signatureHeader = req.headers['x-signature']
   const signature = Array.isArray(signatureHeader) ? signatureHeader[0] : signatureHeader
 
   if (!secret || !signature) {
-    res.status?.(401).json?.({ message: "Invalid signature" })
+    res.status?.(401).json?.({ message: 'Invalid signature' })
     return
   }
 
   const rawBody =
-    typeof req.rawBody === "string" || Buffer.isBuffer(req.rawBody)
+    typeof req.rawBody === 'string' || Buffer.isBuffer(req.rawBody)
       ? req.rawBody
-      : typeof req.body === "string"
-      ? req.body
-      : undefined
+      : typeof req.body === 'string'
+        ? req.body
+        : undefined
 
   if (!rawBody) {
-    res.status?.(400).json?.({ message: "Missing raw body" })
+    res.status?.(400).json?.({ message: 'Missing raw body' })
     return
   }
 
-  const computed = crypto.createHmac("sha256", secret).update(rawBody).digest("hex")
+  const computed = crypto.createHmac('sha256', secret).update(rawBody).digest('hex')
 
-  const incoming = Buffer.from(signature, "hex")
-  const expected = Buffer.from(computed, "hex")
+  const incoming = Buffer.from(signature, 'hex')
+  const expected = Buffer.from(computed, 'hex')
 
   if (incoming.length === expected.length && crypto.timingSafeEqual(incoming, expected)) {
     return next()
   }
 
-  res.status?.(401).json?.({ message: "Invalid signature" })
+  res.status?.(401).json?.({ message: 'Invalid signature' })
 }

--- a/src/modules/keygen/models/license.ts
+++ b/src/modules/keygen/models/license.ts
@@ -1,14 +1,13 @@
+import { model } from '@medusajs/framework/utils'
 
-import { model } from "@medusajs/framework/utils"
-
-const KeygenLicense = model.define("keygen_license", {
+const KeygenLicense = model.define('keygen_license', {
   id: model.id().primaryKey(),
   order_id: model.text(),
   order_item_id: model.text().nullable(),
   customer_id: model.text().nullable(),
   keygen_license_id: model.text().nullable(),
   license_key: model.text().nullable(),
-  status: model.enum(["created", "suspended", "revoked"]).default("created"),
+  status: model.enum(['created', 'suspended', 'revoked']).default('created'),
   keygen_policy_id: model.text().nullable(),
   keygen_product_id: model.text().nullable(),
   notes: model.text().nullable(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-
 export type KeygenPluginOptions = {
   policyMetadataKey?: string
   productMetadataKey?: string

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*", "src/__tests__/**/*", "src/admin/**/*"],
+  "exclude": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,15 +11,8 @@
     "rootDir": "src",
     "resolveJsonModule": true,
     "strict": true,
-    "types": [
-      "vitest/globals"
-    ]
+    "types": ["vitest/globals"]
   },
-  "include": [
-    "src"
-  ],
-  "exclude": [
-    "src/__tests__",
-    "src/admin"
-  ]
+  "include": ["src"],
+  "exclude": ["src/__tests__", "src/admin"]
 }


### PR DESCRIPTION
## Summary
- add ESLint and Prettier configuration based on medusa-plugin-meilisearch
- add scripts and dev dependencies for linting and formatting
- format existing files to satisfy new rules

## Testing
- `npm run lint`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a0f155acc0833190697ba789191c70